### PR TITLE
KAFKA-14960: [Part I]TopicMetadataRequestManager Implementation

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
@@ -98,6 +98,7 @@ public class CommitRequestManager implements RequestManager {
             return new NetworkClientDelegate.PollResult(Long.MAX_VALUE, Collections.emptyList());
         }
 
+        pendingRequests.inflightOffsetFetches.forEach(System.out::println);
         return new NetworkClientDelegate.PollResult(Long.MAX_VALUE,
                 Collections.unmodifiableList(pendingRequests.drain(currentTimeMs)));
     }
@@ -120,7 +121,7 @@ public class CommitRequestManager implements RequestManager {
 
     /**
      * Handles {@link org.apache.kafka.clients.consumer.internals.events.CommitApplicationEvent}. It creates an
-     * {@link OffsetCommitRequestState} and enqueue it to send later.
+     * {@link CompletableOffsetCommitRequest} and enqueue it to send later.
      */
     public CompletableFuture<ClientResponse> addOffsetCommitRequest(final Map<TopicPartition, OffsetAndMetadata> offsets) {
         return pendingRequests.addOffsetCommitRequest(offsets);
@@ -128,7 +129,7 @@ public class CommitRequestManager implements RequestManager {
 
     /**
      * Handles {@link org.apache.kafka.clients.consumer.internals.events.OffsetFetchApplicationEvent}. It creates an
-     * {@link OffsetFetchRequestState} and enqueue it to send later.
+     * {@link CompletableOffsetFetchRequest} and enqueue it to send later.
      */
     public CompletableFuture<Map<TopicPartition, OffsetAndMetadata>> addOffsetFetchRequest(final Set<TopicPartition> partitions) {
         return pendingRequests.addOffsetFetchRequest(partitions);
@@ -140,12 +141,12 @@ public class CommitRequestManager implements RequestManager {
 
 
     // Visible for testing
-    List<OffsetFetchRequestState> unsentOffsetFetchRequests() {
+    List<CompletableOffsetFetchRequest> unsentOffsetFetchRequests() {
         return pendingRequests.unsentOffsetFetches;
     }
 
     // Visible for testing
-    Queue<OffsetCommitRequestState> unsentOffsetCommitRequests() {
+    Queue<CompletableOffsetCommitRequest> unsentOffsetCommitRequests() {
         return pendingRequests.unsentOffsetCommits;
     }
 
@@ -170,26 +171,20 @@ public class CommitRequestManager implements RequestManager {
                 });
     }
 
-    private class OffsetCommitRequestState {
+    private class CompletableOffsetCommitRequest extends CompletableRequest<ClientResponse> {
         private final Map<TopicPartition, OffsetAndMetadata> offsets;
         private final String groupId;
         private final GroupState.Generation generation;
         private final String groupInstanceId;
-        private final NetworkClientDelegate.FutureCompletionHandler future;
 
-        public OffsetCommitRequestState(final Map<TopicPartition, OffsetAndMetadata> offsets,
-                                        final String groupId,
-                                        final String groupInstanceId,
-                                        final GroupState.Generation generation) {
+        public CompletableOffsetCommitRequest(final Map<TopicPartition, OffsetAndMetadata> offsets,
+                                              final String groupId,
+                                              final String groupInstanceId,
+                                              final GroupState.Generation generation) {
             this.offsets = offsets;
-            this.future = new NetworkClientDelegate.FutureCompletionHandler();
             this.groupId = groupId;
             this.generation = generation;
             this.groupInstanceId = groupInstanceId;
-        }
-
-        public CompletableFuture<ClientResponse> future() {
-            return future.future();
         }
 
         public NetworkClientDelegate.UnsentRequest toUnsentRequest() {
@@ -199,49 +194,54 @@ public class CommitRequestManager implements RequestManager {
                 OffsetAndMetadata offsetAndMetadata = entry.getValue();
 
                 OffsetCommitRequestData.OffsetCommitRequestTopic topic = requestTopicDataMap
-                        .getOrDefault(topicPartition.topic(),
-                                new OffsetCommitRequestData.OffsetCommitRequestTopic()
-                                        .setName(topicPartition.topic())
-                        );
+                    .getOrDefault(topicPartition.topic(),
+                        new OffsetCommitRequestData.OffsetCommitRequestTopic()
+                            .setName(topicPartition.topic())
+                    );
 
                 topic.partitions().add(new OffsetCommitRequestData.OffsetCommitRequestPartition()
-                        .setPartitionIndex(topicPartition.partition())
-                        .setCommittedOffset(offsetAndMetadata.offset())
-                        .setCommittedLeaderEpoch(offsetAndMetadata.leaderEpoch().orElse(RecordBatch.NO_PARTITION_LEADER_EPOCH))
-                        .setCommittedMetadata(offsetAndMetadata.metadata())
+                    .setPartitionIndex(topicPartition.partition())
+                    .setCommittedOffset(offsetAndMetadata.offset())
+                    .setCommittedLeaderEpoch(offsetAndMetadata.leaderEpoch().orElse(RecordBatch.NO_PARTITION_LEADER_EPOCH))
+                    .setCommittedMetadata(offsetAndMetadata.metadata())
                 );
                 requestTopicDataMap.put(topicPartition.topic(), topic);
             }
 
             OffsetCommitRequest.Builder builder = new OffsetCommitRequest.Builder(
-                    new OffsetCommitRequestData()
-                            .setGroupId(this.groupId)
-                            .setGenerationId(generation.generationId)
-                            .setMemberId(generation.memberId)
-                            .setGroupInstanceId(groupInstanceId)
-                            .setTopics(new ArrayList<>(requestTopicDataMap.values())));
+                new OffsetCommitRequestData()
+                    .setGroupId(this.groupId)
+                    .setGenerationId(generation.generationId)
+                    .setMemberId(generation.memberId)
+                    .setGroupInstanceId(groupInstanceId)
+                    .setTopics(new ArrayList<>(requestTopicDataMap.values())));
             return new NetworkClientDelegate.UnsentRequest(
-                    builder,
-                    coordinatorRequestManager.coordinator(),
-                    future);
+                builder,
+                coordinatorRequestManager.coordinator(),
+                (response, throwable) -> {
+                    if (throwable == null) {
+                        this.future().complete(response);
+                    } else {
+                        this.future().completeExceptionally(throwable);
+                    }
+                });
         }
     }
 
-    private class OffsetFetchRequestState extends RequestState {
+    private class CompletableOffsetFetchRequest extends CompletableRequest<Map<TopicPartition, OffsetAndMetadata>> {
         public final Set<TopicPartition> requestedPartitions;
         public final GroupState.Generation requestedGeneration;
-        public CompletableFuture<Map<TopicPartition, OffsetAndMetadata>> future;
+        private final RequestState requestState;
 
-        public OffsetFetchRequestState(final Set<TopicPartition> partitions,
-                                       final GroupState.Generation generation,
-                                       final long retryBackoffMs) {
-            super(logContext, retryBackoffMs);
+        public CompletableOffsetFetchRequest(final Set<TopicPartition> partitions,
+                                             final GroupState.Generation generation,
+                                             final long retryBackoffMs) {
             this.requestedPartitions = partitions;
             this.requestedGeneration = generation;
-            this.future = new CompletableFuture<>();
+            this.requestState = new RequestState(logContext, retryBackoffMs);
         }
 
-        public boolean sameRequest(final OffsetFetchRequestState request) {
+        public boolean sameRequest(final CompletableOffsetFetchRequest request) {
             return Objects.equals(requestedGeneration, request.requestedGeneration) && requestedPartitions.equals(request.requestedPartitions);
         }
 
@@ -252,11 +252,9 @@ public class CommitRequestManager implements RequestManager {
                     new ArrayList<>(this.requestedPartitions),
                     throwOnFetchStableOffsetUnsupported);
             NetworkClientDelegate.UnsentRequest unsentRequest = new NetworkClientDelegate.UnsentRequest(
-                    builder,
-                    coordinatorRequestManager.coordinator());
-            unsentRequest.future().whenComplete((r, t) -> {
-                onResponse(currentTimeMs, (OffsetFetchResponse) r.responseBody());
-            });
+                builder,
+                coordinatorRequestManager.coordinator(),
+                (r, t) -> onResponse(currentTimeMs, (OffsetFetchResponse) r.responseBody()));
             return unsentRequest;
         }
 
@@ -283,15 +281,15 @@ public class CommitRequestManager implements RequestManager {
                 coordinatorRequestManager.markCoordinatorUnknown(responseError.message(), Time.SYSTEM.milliseconds());
                 retry(currentTimeMs);
             } else if (responseError == Errors.GROUP_AUTHORIZATION_FAILED) {
-                future.completeExceptionally(GroupAuthorizationException.forGroupId(groupState.groupId));
+                future().completeExceptionally(GroupAuthorizationException.forGroupId(groupState.groupId));
             } else {
-                future.completeExceptionally(new KafkaException("Unexpected error in fetch offset response: " + responseError.message()));
+                future().completeExceptionally(new KafkaException("Unexpected error in fetch offset response: " + responseError.message()));
             }
         }
 
         private void retry(final long currentTimeMs) {
-            onFailedAttempt(currentTimeMs);
-            onSendAttempt(currentTimeMs);
+            this.requestState.onFailedAttempt(currentTimeMs);
+            this.requestState.onSendAttempt(currentTimeMs);
             pendingRequests.addOffsetFetchRequest(this);
         }
 
@@ -310,7 +308,7 @@ public class CommitRequestManager implements RequestManager {
                     log.debug("Failed to fetch offset for partition {}: {}", tp, error.message());
 
                     if (error == Errors.UNKNOWN_TOPIC_OR_PARTITION) {
-                        future.completeExceptionally(new KafkaException("Topic or Partition " + tp + " does " +
+                        future().completeExceptionally(new KafkaException("Topic or Partition " + tp + " does " +
                                 "not " +
                                 "exist"));
                         return;
@@ -322,7 +320,7 @@ public class CommitRequestManager implements RequestManager {
                     } else if (error == Errors.UNSTABLE_OFFSET_COMMIT) {
                         unstableTxnOffsetTopicPartitions.add(tp);
                     } else {
-                        future.completeExceptionally(new KafkaException("Unexpected error in fetch offset " +
+                        future().completeExceptionally(new KafkaException("Unexpected error in fetch offset " +
                                 "response for partition " + tp + ": " + error.message()));
                         return;
                     }
@@ -337,7 +335,7 @@ public class CommitRequestManager implements RequestManager {
             }
 
             if (unauthorizedTopics != null) {
-                future.completeExceptionally(new TopicAuthorizationException(unauthorizedTopics));
+                future().completeExceptionally(new TopicAuthorizationException(unauthorizedTopics));
             } else if (!unstableTxnOffsetTopicPartitions.isEmpty()) {
                 // TODO: Optimization question: Do we need to retry all partitions upon a single partition error?
                 log.info("The following partitions still have unstable offsets " +
@@ -347,43 +345,43 @@ public class CommitRequestManager implements RequestManager {
                         "normal offsets waiting for replication after appending to local log", unstableTxnOffsetTopicPartitions);
                 retry(currentTimeMs);
             } else {
-                future.complete(offsets);
+                future().complete(offsets);
             }
         }
 
-        private CompletableFuture<Map<TopicPartition, OffsetAndMetadata>> chainFuture(final CompletableFuture<Map<TopicPartition, OffsetAndMetadata>> future) {
-            return this.future.whenComplete((r, t) -> {
+        private CompletableFuture<Map<TopicPartition, OffsetAndMetadata>> chainFuture(final CompletableFuture<Map<TopicPartition, OffsetAndMetadata>> otherFuture) {
+            return this.future().whenComplete((r, t) -> {
                 if (t != null) {
-                    future.completeExceptionally(t);
+                    otherFuture.completeExceptionally(t);
                 } else {
-                    future.complete(r);
+                    otherFuture.complete(r);
                 }
             });
         }
     }
 
     /**
-     * <p>This is used to stage the unsent {@link OffsetCommitRequestState} and {@link OffsetFetchRequestState}.
+     * <p>This is used to stage the unsent {@link CompletableOffsetCommitRequest} and {@link CompletableOffsetFetchRequest}.
      * <li>unsentOffsetCommits holds the offset commit requests that have not been sent out</>
      * <li>unsentOffsetFetches holds the offset fetch requests that have not been sent out</li>
-     * <li>inflightOffsetFetches holds the offset fetch requests that have been sent out but incompleted</>.
+     * <li>inflightOffsetFetches holds the offset fetch requests that have been sent out but not completed</>.
      *
      * {@code addOffsetFetchRequest} dedupes the requests to avoid sending the same requests.
      */
 
     class PendingRequests {
         // Queue is used to ensure the sequence of commit
-        Queue<OffsetCommitRequestState> unsentOffsetCommits = new LinkedList<>();
-        List<OffsetFetchRequestState> unsentOffsetFetches = new ArrayList<>();
-        List<OffsetFetchRequestState> inflightOffsetFetches = new ArrayList<>();
+        Queue<CompletableOffsetCommitRequest> unsentOffsetCommits = new LinkedList<>();
+        List<CompletableOffsetFetchRequest> unsentOffsetFetches = new ArrayList<>();
+        List<CompletableOffsetFetchRequest> inflightOffsetFetches = new ArrayList<>();
 
         public boolean hasUnsentRequests() {
             return !unsentOffsetCommits.isEmpty() || !unsentOffsetFetches.isEmpty();
         }
 
-        public CompletableFuture<ClientResponse> addOffsetCommitRequest(final Map<TopicPartition, OffsetAndMetadata> offsets) {
+        CompletableFuture<ClientResponse> addOffsetCommitRequest(final Map<TopicPartition, OffsetAndMetadata> offsets) {
             // TODO: Dedupe committing the same offsets to the same partitions
-            OffsetCommitRequestState request = new OffsetCommitRequestState(
+            CompletableOffsetCommitRequest request = new CompletableOffsetCommitRequest(
                     offsets,
                     groupState.groupId,
                     groupState.groupInstanceId.orElse(null),
@@ -399,18 +397,18 @@ public class CommitRequestManager implements RequestManager {
          *  <p>If the request is new, it invokes a callback to remove itself from the {@code inflightOffsetFetches}
          *  upon completion.</>
          */
-        private CompletableFuture<Map<TopicPartition, OffsetAndMetadata>> addOffsetFetchRequest(final OffsetFetchRequestState request) {
-            Optional<OffsetFetchRequestState> dupe =
+        private CompletableFuture<Map<TopicPartition, OffsetAndMetadata>> addOffsetFetchRequest(final CompletableOffsetFetchRequest request) {
+            Optional<CompletableOffsetFetchRequest> dupe =
                     unsentOffsetFetches.stream().filter(r -> r.sameRequest(request)).findAny();
-            Optional<OffsetFetchRequestState> inflight =
+            Optional<CompletableOffsetFetchRequest> inflight =
                     inflightOffsetFetches.stream().filter(r -> r.sameRequest(request)).findAny();
 
             if (dupe.isPresent() || inflight.isPresent()) {
                 log.info("Duplicated OffsetFetchRequest: " + request.requestedPartitions);
-                dupe.orElseGet(() -> inflight.get()).chainFuture(request.future);
+                dupe.orElseGet(() -> inflight.get()).chainFuture(request.future());
             } else {
                 // remove the request from the outbound buffer: inflightOffsetFetches
-                request.future.whenComplete((r, t) -> {
+                request.future().whenComplete((r, t) -> {
                     if (!inflightOffsetFetches.remove(request)) {
                         log.warn("A duplicated, inflight, request was identified, but unable to find it in the " +
                                 "outbound buffer:" + request);
@@ -418,11 +416,11 @@ public class CommitRequestManager implements RequestManager {
                 });
                 this.unsentOffsetFetches.add(request);
             }
-            return request.future;
+            return request.future();
         }
 
         private CompletableFuture<Map<TopicPartition, OffsetAndMetadata>> addOffsetFetchRequest(final Set<TopicPartition> partitions) {
-            OffsetFetchRequestState request = new OffsetFetchRequestState(
+            CompletableOffsetFetchRequest request = new CompletableOffsetFetchRequest(
                     partitions,
                     groupState.generation,
                     retryBackoffMs);
@@ -442,17 +440,17 @@ public class CommitRequestManager implements RequestManager {
             // Add all unsent offset commit requests to the unsentRequests list
             unsentRequests.addAll(
                     unsentOffsetCommits.stream()
-                            .map(OffsetCommitRequestState::toUnsentRequest)
+                            .map(CompletableOffsetCommitRequest::toUnsentRequest)
                             .collect(Collectors.toList()));
 
             // Partition the unsent offset fetch requests into sendable and non-sendable lists
-            Map<Boolean, List<OffsetFetchRequestState>> partitionedBySendability =
+            Map<Boolean, List<CompletableOffsetFetchRequest>> partitionedBySendability =
                     unsentOffsetFetches.stream()
-                            .collect(Collectors.partitioningBy(request -> request.canSendRequest(currentTimeMs)));
+                            .collect(Collectors.partitioningBy(request -> request.requestState.canSendRequest(currentTimeMs)));
 
             // Add all sendable offset fetch requests to the unsentRequests list and to the inflightOffsetFetches list
-            for (OffsetFetchRequestState request : partitionedBySendability.get(true)) {
-                request.onSendAttempt(currentTimeMs);
+            for (CompletableOffsetFetchRequest request : partitionedBySendability.get(true)) {
+                request.requestState.onSendAttempt(currentTimeMs);
                 unsentRequests.add(request.toUnsentRequest(currentTimeMs));
                 inflightOffsetFetches.add(request);
             }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CompletableRequest.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CompletableRequest.java
@@ -14,27 +14,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.kafka.clients.consumer.internals.events;
+package org.apache.kafka.clients.consumer.internals;
 
-import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
 
-/**
- * This is the abstract definition of the events created by the KafkaConsumer API
- */
-public abstract class ApplicationEvent {
+public class CompletableRequest<T> {
+    private final CompletableFuture<T> future;
 
-    public enum Type {
-        NOOP, COMMIT, POLL, FETCH, FETCH_COMMITTED_OFFSET, METADATA_UPDATE, UNSUBSCRIBE,
-        LIST_OFFSETS, TOPIC_METADATA
+    public CompletableRequest() {
+        this.future = new CompletableFuture<>();
     }
 
-    protected final Type type;
-
-    protected ApplicationEvent(Type type) {
-        this.type = Objects.requireNonNull(type);
-    }
-
-    public Type type() {
-        return type;
+    public CompletableFuture<T> future() {
+        return this.future;
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CompletableRequest.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CompletableRequest.java
@@ -18,6 +18,11 @@ package org.apache.kafka.clients.consumer.internals;
 
 import java.util.concurrent.CompletableFuture;
 
+/**
+ * A request that is completable by the user. This is used to wrap requests that are sent to the background thread
+ * for completion.
+ * @param <T> The type of the response.
+ */
 public class CompletableRequest<T> {
     private final CompletableFuture<T> future;
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThread.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThread.java
@@ -131,14 +131,14 @@ public class DefaultBackgroundThread extends KafkaThread {
             this.metadata = metadata;
 
             final NetworkClient networkClient = ClientUtils.createNetworkClient(config,
-                    metrics,
-                    CONSUMER_METRIC_GROUP_PREFIX,
-                    logContext,
-                    apiVersions,
-                    time,
-                    CONSUMER_MAX_INFLIGHT_REQUESTS_PER_CONNECTION,
-                    metadata,
-                    fetcherThrottleTimeSensor);
+                metrics,
+                CONSUMER_METRIC_GROUP_PREFIX,
+                logContext,
+                apiVersions,
+                time,
+                CONSUMER_MAX_INFLIGHT_REQUESTS_PER_CONNECTION,
+                metadata,
+                fetcherThrottleTimeSensor);
 
             this.networkClientDelegate = new NetworkClientDelegate(this.time, this.config, logContext, networkClient);
             this.errorEventHandler = new ErrorEventHandler(this.backgroundEventQueue);
@@ -146,13 +146,13 @@ public class DefaultBackgroundThread extends KafkaThread {
             long retryBackoffMs = config.getLong(ConsumerConfig.RETRY_BACKOFF_MS_CONFIG);
 
             ListOffsetsRequestManager offsetsRequestManager =
-                    new ListOffsetsRequestManager(
-                            subscriptionState,
-                            metadata,
-                            getConfiguredIsolationLevel(config),
-                            time,
-                            apiVersions,
-                            logContext);
+                new ListOffsetsRequestManager(
+                    subscriptionState,
+                    metadata,
+                    getConfiguredIsolationLevel(config),
+                    time,
+                    apiVersions,
+                    logContext);
             CoordinatorRequestManager coordinatorRequestManager = null;
             CommitRequestManager commitRequestManager = null;
             TopicMetadataRequestManager topicMetadataRequestManger = new TopicMetadataRequestManager(
@@ -161,34 +161,27 @@ public class DefaultBackgroundThread extends KafkaThread {
 
             if (groupState.groupId != null) {
                 coordinatorRequestManager = new CoordinatorRequestManager(this.time,
-                        logContext,
-                        retryBackoffMs, // TODO: let's pass in the config directly
-                        this.errorEventHandler,
-                        groupState.groupId);
+                    logContext,
+                    retryBackoffMs, // TODO: let's pass in the config directly
+                    this.errorEventHandler,
+                    groupState.groupId);
                 commitRequestManager = new CommitRequestManager(this.time,
-                        logContext,
-                        subscriptions,
-                        config,
-                        coordinatorRequestManager,
-                        groupState);
-                this.requestManagers = new RequestManagers(
-                    offsetsRequestManager,
-                    topicMetadataRequestManger,
-                    Optional.of(coordinatorRequestManager),
-                    Optional.of(commitRequestManager));
-            } else {
-                this.requestManagers = new RequestManagers(
-                    offsetsRequestManager,
-                    topicMetadataRequestManger,
-                    Optional.empty(),
-                    Optional.empty());
+                    logContext,
+                    subscriptions,
+                    config,
+                    coordinatorRequestManager,
+                    groupState);
             }
 
+            this.requestManagers = new RequestManagers(
+                offsetsRequestManager,
+                topicMetadataRequestManger,
+                Optional.ofNullable(coordinatorRequestManager),
+                Optional.ofNullable(commitRequestManager));
             this.applicationEventProcessor = new ApplicationEventProcessor(
-                    backgroundEventQueue,
-                    requestManagers,
-                    metadata);
-
+                backgroundEventQueue,
+                requestManagers,
+                metadata);
         } catch (final Exception e) {
             close();
             throw new KafkaException("Failed to construct background processor", e.getCause());

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThread.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThread.java
@@ -156,7 +156,6 @@ public class DefaultBackgroundThread extends KafkaThread {
             CoordinatorRequestManager coordinatorRequestManager = null;
             CommitRequestManager commitRequestManager = null;
             TopicMetadataRequestManager topicMetadataRequestManger = new TopicMetadataRequestManager(
-                this.time,
                 logContext,
                 config);
 
@@ -173,9 +172,10 @@ public class DefaultBackgroundThread extends KafkaThread {
                         coordinatorRequestManager,
                         groupState);
                 this.requestManagers = new RequestManagers(
-                    Optional.of(coordinatorManager),
-                    Optional.of(commitRequestManager),
-                    topicMetadataRequestManger);
+                    offsetsRequestManager,
+                    topicMetadataRequestManger,
+                    Optional.of(coordinatorRequestManager),
+                    Optional.of(commitRequestManager));
             } else {
                 this.requestManagers = new RequestManagers(
                     offsetsRequestManager,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestManagers.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestManagers.java
@@ -33,21 +33,23 @@ public class RequestManagers {
     public final Optional<CoordinatorRequestManager> coordinatorRequestManager;
     public final Optional<CommitRequestManager> commitRequestManager;
     public final ListOffsetsRequestManager listOffsetsRequestManager;
+    public final TopicMetadataRequestManager topicMetadataRequestManager;
     private final List<Optional<? extends RequestManager>> entries;
 
     public RequestManagers(ListOffsetsRequestManager listOffsetsRequestManager,
+                           TopicMetadataRequestManager topicMetadataRequestManager,
                            Optional<CoordinatorRequestManager> coordinatorRequestManager,
                            Optional<CommitRequestManager> commitRequestManager) {
-        this.listOffsetsRequestManager = requireNonNull(listOffsetsRequestManager,
-                "ListOffsetsRequestManager cannot be null");
+        this.listOffsetsRequestManager = requireNonNull(listOffsetsRequestManager, "ListOffsetsRequestManager cannot be null");
         this.coordinatorRequestManager = coordinatorRequestManager;
         this.commitRequestManager = commitRequestManager;
-
+        this.topicMetadataRequestManager = topicMetadataRequestManager;
 
         List<Optional<? extends RequestManager>> list = new ArrayList<>();
         list.add(coordinatorRequestManager);
         list.add(commitRequestManager);
         list.add(Optional.of(listOffsetsRequestManager));
+        list.add(Optional.of(topicMetadataRequestManager));
         entries = Collections.unmodifiableList(list);
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/TopicMetadataRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/TopicMetadataRequestManager.java
@@ -1,0 +1,209 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer.internals;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.Cluster;
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.errors.InvalidTopicException;
+import org.apache.kafka.common.errors.RetriableException;
+import org.apache.kafka.common.errors.TopicAuthorizationException;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.MetadataRequest;
+import org.apache.kafka.common.requests.MetadataResponse;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.Time;
+import org.slf4j.Logger;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+/**
+ * <p>
+ * Manages the state of the topic metadata requests.  The manager returns the
+ * {@link org.apache.kafka.clients.consumer.internals.NetworkClientDelegate.PollResult} when the request is ready to
+ * be sent. This manager specifically handles the following user API calls:
+ * <ul>
+ * <li>listOffsets</li>
+ * <li>partitionsFor</li>
+ * </ul>
+ * </p>
+ * <p>
+ *     The manager checks the state of the {@link CompletableTopicMetadataRequest} before sending a new one, to
+ *     prevent sending without backing off from the previous attempts.
+ *     It also checks the state of the inflight requests to prevent overwhelming the broker with duplicated requests.
+ *     The {@code inflightRequests} is memoized by the topic name.  If all topics are requested, then we use {@code
+ *     null} as the key. Once the request is completed successfully, the entry is removed.
+ * </p>
+ */
+public class TopicMetadataRequestManager implements RequestManager {
+    private final boolean allowAutoTopicCreation;
+    private final Map<String, CompletableTopicMetadataRequest> inflightRequests;
+    private final Time time;
+    private final long retryBackoffMs;
+    private final Logger log;
+
+    public TopicMetadataRequestManager(
+        final Time time,
+        final LogContext logContext,
+        final ConsumerConfig config) {
+        this.time = time;
+        this.log = logContext.logger(this.getClass());
+        this.inflightRequests = new HashMap<>();
+        this.retryBackoffMs = config.getLong(ConsumerConfig.RETRY_BACKOFF_MS_CONFIG);
+        this.allowAutoTopicCreation = config.getBoolean(ConsumerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG);
+    }
+
+    @Override
+    public NetworkClientDelegate.PollResult poll(final long currentTimeMs) {
+        List<NetworkClientDelegate.UnsentRequest> requests = inflightRequests.values().stream()
+            .map(req -> req.send(currentTimeMs).orElse(null))
+            .filter(Objects::nonNull)
+            .collect(Collectors.toList());
+        return requests.isEmpty() ?
+            new NetworkClientDelegate.PollResult(Long.MAX_VALUE, new ArrayList<>()) :
+            new NetworkClientDelegate.PollResult(0, Collections.unmodifiableList(requests));
+    }
+
+    /**
+     * return the future of the metadata request. If the same topic was requested but incompleted, return the same
+     * future.
+     *
+     * @param topic to be requested. If empty, return the metadata for all topics.
+     * @return the future of the metadata request.
+     */
+    public CompletableFuture<Map<String, List<PartitionInfo>>> requestTopicMetadata(final Optional<String> topic) {
+        String topicName = topic.orElse(null);
+        if (inflightRequests.containsKey(topicName)) {
+            return inflightRequests.get(topicName).future();
+        }
+
+        CompletableTopicMetadataRequest newRequest = new CompletableTopicMetadataRequest(
+            topic,
+            retryBackoffMs);
+        inflightRequests.put(topicName, newRequest);
+        return newRequest.future();
+    }
+
+    // Visible for testing
+    List<CompletableTopicMetadataRequest> inflightRequests() {
+        return new ArrayList<>(inflightRequests.values());
+    }
+
+    class CompletableTopicMetadataRequest extends CompletableRequest<Map<String, List<PartitionInfo>>> {
+        private final Optional<String> topic;
+        private final RequestState state;
+
+        public CompletableTopicMetadataRequest(final Optional<String> topic,
+                                               final long retryBackoffMs) {
+            this.topic = topic;
+            this.state = new RequestState(retryBackoffMs);
+        }
+
+        /**
+         * prepare the metadata request and return an
+         * {@link org.apache.kafka.clients.consumer.internals.NetworkClientDelegate.UnsentRequest} if needed.
+         */
+        private Optional<NetworkClientDelegate.UnsentRequest> send(final long currentTimeMs) {
+            if (!this.state.canSendRequest(currentTimeMs)) {
+                return Optional.empty();
+            }
+            this.state.onSendAttempt(currentTimeMs);
+
+            final MetadataRequest.Builder request;
+            if (topic.isPresent()) {
+                request = new MetadataRequest.Builder(Collections.singletonList(topic.get()), allowAutoTopicCreation);
+            } else {
+                request = MetadataRequest.Builder.allTopics();
+            }
+
+            final NetworkClientDelegate.UnsentRequest unsent = new NetworkClientDelegate.UnsentRequest(
+                request,
+                Optional.empty(),
+                (response, exception) -> {
+                    if (exception != null) {
+                        this.future().completeExceptionally(new KafkaException(exception));
+                        inflightRequests.remove(topic.orElse(null));
+                        return;
+                    }
+
+                    try {
+                        Map<String, List<PartitionInfo>> res = handleTopicMetadataResponse((MetadataResponse) response.responseBody());
+                        future().complete(res);
+                        inflightRequests.remove(topic.orElse(null));
+                    } catch (RetriableException e) {
+                        this.state.onFailedAttempt(currentTimeMs);
+                    } catch (Exception t) {
+                        this.future().completeExceptionally(t);
+                        inflightRequests.remove(topic.orElse(null));
+                    }
+                });
+            return Optional.of(unsent);
+        }
+
+        private Map<String, List<PartitionInfo>> handleTopicMetadataResponse(final MetadataResponse response) {
+            Cluster cluster = response.buildCluster();
+
+            final Set<String> unauthorizedTopics = cluster.unauthorizedTopics();
+            if (!unauthorizedTopics.isEmpty())
+                throw new TopicAuthorizationException(unauthorizedTopics);
+
+            Map<String, Errors> errors = response.errors();
+            if (!errors.isEmpty()) {
+                // if there were errors, we need to check whether they were fatal or whether
+                // we should just retry
+
+                log.debug("Topic metadata fetch included errors: {}", errors);
+
+                for (Map.Entry<String, Errors> errorEntry : errors.entrySet()) {
+                    String topic = errorEntry.getKey();
+                    Errors error = errorEntry.getValue();
+
+                    if (error == Errors.INVALID_TOPIC_EXCEPTION)
+                        throw new InvalidTopicException("Topic '" + topic + "' is invalid");
+                    else if (error == Errors.UNKNOWN_TOPIC_OR_PARTITION)
+                        // if a requested topic is unknown, we just continue and let it be absent
+                        // in the returned map
+                        continue;
+                    else if (error.exception() instanceof RetriableException) {
+                        throw error.exception();
+                    } else
+                        throw new KafkaException("Unexpected error fetching metadata for topic " + topic,
+                            error.exception());
+                }
+            }
+
+            HashMap<String, List<PartitionInfo>> topicsPartitionInfos = new HashMap<>();
+            for (String topic : cluster.topics())
+                topicsPartitionInfos.put(topic, cluster.partitionsForTopic(topic));
+            return topicsPartitionInfos;
+        }
+
+        public String topic() {
+            return topic.orElse(null);
+        }
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/TopicMetadataRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/TopicMetadataRequestManager.java
@@ -64,9 +64,7 @@ public class TopicMetadataRequestManager implements RequestManager {
     private final Logger log;
     private final LogContext logContext;
 
-    public TopicMetadataRequestManager(
-        final LogContext logContext,
-        final ConsumerConfig config) {
+    public TopicMetadataRequestManager(final LogContext logContext, final ConsumerConfig config) {
         this.logContext = logContext;
         this.log = logContext.logger(this.getClass());
         this.inflightRequests = new HashMap<>();

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/CommitApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/CommitApplicationEvent.java
@@ -16,14 +16,14 @@
  */
 package org.apache.kafka.clients.consumer.internals.events;
 
+import org.apache.kafka.clients.ClientResponse;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 
 import java.util.Collections;
 import java.util.Map;
 
-public class CommitApplicationEvent extends CompletableApplicationEvent<Void> {
-
+public class CommitApplicationEvent extends CompletableApplicationEvent<ClientResponse> {
     private final Map<TopicPartition, OffsetAndMetadata> offsets;
 
     public CommitApplicationEvent(final Map<TopicPartition, OffsetAndMetadata> offsets) {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/CommitApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/CommitApplicationEvent.java
@@ -16,14 +16,13 @@
  */
 package org.apache.kafka.clients.consumer.internals.events;
 
-import org.apache.kafka.clients.ClientResponse;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 
 import java.util.Collections;
 import java.util.Map;
 
-public class CommitApplicationEvent extends CompletableApplicationEvent<ClientResponse> {
+public class CommitApplicationEvent extends CompletableApplicationEvent<Void> {
     private final Map<TopicPartition, OffsetAndMetadata> offsets;
 
     public CommitApplicationEvent(final Map<TopicPartition, OffsetAndMetadata> offsets) {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/CompletableApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/CompletableApplicationEvent.java
@@ -20,6 +20,7 @@ import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.errors.InterruptException;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.utils.Timer;
+
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -54,4 +55,13 @@ public abstract class CompletableApplicationEvent<T> extends ApplicationEvent {
         }
     }
 
+    public void chain(final CompletableFuture<T> providedFuture) {
+        providedFuture.whenComplete((value, exception) -> {
+            if (exception != null) {
+                this.future.completeExceptionally(exception);
+            } else {
+                this.future.complete(value);
+            }
+        });
+    }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/TopicMetadataApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/TopicMetadataApplicationEvent.java
@@ -16,25 +16,19 @@
  */
 package org.apache.kafka.clients.consumer.internals.events;
 
-import java.util.Objects;
+import org.apache.kafka.common.PartitionInfo;
 
-/**
- * This is the abstract definition of the events created by the KafkaConsumer API
- */
-public abstract class ApplicationEvent {
+import java.util.List;
+import java.util.Map;
 
-    public enum Type {
-        NOOP, COMMIT, POLL, FETCH, FETCH_COMMITTED_OFFSET, METADATA_UPDATE, UNSUBSCRIBE,
-        LIST_OFFSETS, TOPIC_METADATA
+public class TopicMetadataApplicationEvent extends CompletableApplicationEvent<Map<String, List<PartitionInfo>>> {
+    private final String topic;
+    public TopicMetadataApplicationEvent(final String topic) {
+        super(Type.TOPIC_METADATA);
+        this.topic = topic;
     }
 
-    protected final Type type;
-
-    protected ApplicationEvent(Type type) {
-        this.type = Objects.requireNonNull(type);
-    }
-
-    public Type type() {
-        return type;
+    public String topic() {
+        return topic;
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CommitRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CommitRequestManagerTest.java
@@ -120,7 +120,7 @@ public class CommitRequestManagerTest {
         offsets2.put(new TopicPartition("test", 4), new OffsetAndMetadata(20L));
 
         // Add the requests to the CommitRequestManager and store their futures
-        ArrayList<CompletableFuture<ClientResponse>> commitFutures = new ArrayList<>();
+        ArrayList<CompletableFuture<Void>> commitFutures = new ArrayList<>();
         ArrayList<CompletableFuture<Map<TopicPartition, OffsetAndMetadata>>> fetchFutures = new ArrayList<>();
         commitFutures.add(commitManager.addOffsetCommitRequest(offsets1));
         fetchFutures.add(commitManager.addOffsetFetchRequest(Collections.singleton(new TopicPartition("test", 0))));

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/IdempotentCloserTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/IdempotentCloserTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class IdempotentCloserTest {
 
-    private static final Runnable CALLBACK_NO_OP = () -> {};
+    private static final Runnable CALLBACK_NO_OP = () -> { };
 
     private static final Runnable CALLBACK_WITH_RUNTIME_EXCEPTION = () -> {
         throw new RuntimeException("Simulated error during callback");

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/TopicMetadataRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/TopicMetadataRequestManagerTest.java
@@ -71,7 +71,6 @@ public class TopicMetadataRequestManagerTest {
         this.props.put(KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         this.props.put(VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         this.topicMetadataRequestManager = new TopicMetadataRequestManager(
-            this.time,
             new LogContext(),
             new ConsumerConfig(props));
     }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/TopicMetadataRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/TopicMetadataRequestManagerTest.java
@@ -1,0 +1,192 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer.internals;
+
+import org.apache.kafka.clients.ClientResponse;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.Cluster;
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.AbstractRequest;
+import org.apache.kafka.common.requests.MetadataRequest;
+import org.apache.kafka.common.requests.MetadataResponse;
+import org.apache.kafka.common.requests.RequestHeader;
+import org.apache.kafka.common.requests.RequestTestUtils;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.MockTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
+
+import static org.apache.kafka.clients.consumer.ConsumerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TopicMetadataRequestManagerTest {
+    private MockTime time;
+    private TopicMetadataRequestManager topicMetadataRequestManager;
+
+    private Properties props;
+
+    @BeforeEach
+    public void setup() {
+        this.time = new MockTime();
+        this.props = new Properties();
+        this.props.put(ConsumerConfig.RETRY_BACKOFF_MS_CONFIG, 100);
+        this.props.put(ALLOW_AUTO_CREATE_TOPICS_CONFIG, false);
+        this.props.put(KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        this.props.put(VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        this.topicMetadataRequestManager = new TopicMetadataRequestManager(
+            this.time,
+            new LogContext(),
+            new ConsumerConfig(props));
+    }
+
+    @ParameterizedTest
+    @MethodSource("topicsProvider")
+    public void testPoll_SuccessfulRequestTopicMetadata(Optional<String> topic) {
+        this.topicMetadataRequestManager.requestTopicMetadata(topic);
+        this.time.sleep(100);
+        NetworkClientDelegate.PollResult res = this.topicMetadataRequestManager.poll(this.time.milliseconds());
+        assertEquals(1, res.unsentRequests.size());
+    }
+
+    @ParameterizedTest
+    @MethodSource("exceptionProvider")
+    public void testExceptionAndInflightRequests(final Errors error, final boolean shouldRetry) {
+        String topic = "hello";
+        this.topicMetadataRequestManager.requestTopicMetadata(Optional.of("hello"));
+        this.time.sleep(100);
+        NetworkClientDelegate.PollResult res = this.topicMetadataRequestManager.poll(this.time.milliseconds());
+        res.unsentRequests.get(0).future().complete(buildTopicMetadataClientResponse(
+            res.unsentRequests.get(0),
+            topic,
+            error));
+        List<TopicMetadataRequestManager.CompletableTopicMetadataRequest> inflights = this.topicMetadataRequestManager.inflightRequests();
+
+        if (shouldRetry) {
+            assertEquals(1, inflights.size());
+            assertEquals(topic, inflights.get(0).topic());
+        } else {
+            assertEquals(0, inflights.size());
+        }
+    }
+
+    @Test
+    public void testEnsureRequestRemovedFromInflightsOnErrorResponse() {
+        this.topicMetadataRequestManager.requestTopicMetadata(Optional.of("hello"));
+        this.time.sleep(100);
+        NetworkClientDelegate.PollResult res = this.topicMetadataRequestManager.poll(this.time.milliseconds());
+        res.unsentRequests.get(0).future().completeExceptionally(new KafkaException("some error"));
+
+        List<TopicMetadataRequestManager.CompletableTopicMetadataRequest> inflights = this.topicMetadataRequestManager.inflightRequests();
+        assertTrue(inflights.isEmpty());
+    }
+
+    @Test
+    public void testSendingTheSameRequest() {
+        final String topic = "hello";
+        CompletableFuture<Map<String, List<PartitionInfo>>> future = this.topicMetadataRequestManager.requestTopicMetadata(Optional.of(topic));
+        CompletableFuture<Map<String, List<PartitionInfo>>> future2 =
+            this.topicMetadataRequestManager.requestTopicMetadata(Optional.of(topic));
+        this.time.sleep(100);
+        NetworkClientDelegate.PollResult res = this.topicMetadataRequestManager.poll(this.time.milliseconds());
+        assertEquals(1, res.unsentRequests.size());
+
+        res.unsentRequests.get(0).future().complete(buildTopicMetadataClientResponse(
+            res.unsentRequests.get(0),
+            topic,
+            Errors.NONE));
+
+        assertTrue(future.isDone());
+        assertFalse(future.isCompletedExceptionally());
+        assertTrue(future2.isDone());
+        assertFalse(future2.isCompletedExceptionally());
+    }
+
+    private ClientResponse buildTopicMetadataClientResponse(
+        final NetworkClientDelegate.UnsentRequest request,
+        final String topic,
+        final Errors error) {
+        AbstractRequest abstractRequest = request.requestBuilder().build();
+        assertTrue(abstractRequest instanceof MetadataRequest);
+        MetadataRequest metadataRequest = (MetadataRequest) abstractRequest;
+        Cluster cluster = mockCluster(3, 0);
+        List<MetadataResponse.TopicMetadata> topics = new ArrayList<>();
+        topics.add(new MetadataResponse.TopicMetadata(error, topic, false,
+            Collections.emptyList()));
+        final MetadataResponse metadataResponse = RequestTestUtils.metadataResponse(cluster.nodes(),
+            cluster.clusterResource().clusterId(),
+            cluster.controller().id(),
+            topics);
+        return new ClientResponse(
+            new RequestHeader(ApiKeys.METADATA, metadataRequest.version(), "mockClientId", 1),
+            request.callback(),
+            "-1",
+            time.milliseconds(),
+            time.milliseconds(),
+            false,
+            null,
+            null,
+            metadataResponse);
+    }
+
+    private static Cluster mockCluster(final int numNodes, final int controllerIndex) {
+        HashMap<Integer, Node> nodes = new HashMap<>();
+        for (int i = 0; i < numNodes; i++)
+            nodes.put(i, new Node(i, "localhost", 8121 + i));
+        return new Cluster("mockClusterId", nodes.values(),
+            Collections.emptySet(), Collections.emptySet(),
+            Collections.emptySet(), nodes.get(controllerIndex));
+    }
+
+
+    private static Collection<Arguments> topicsProvider() {
+        return Arrays.asList(
+            Arguments.of(Optional.of("topic1")),
+            Arguments.of(Optional.empty()));
+    }
+
+    private static Collection<Arguments> exceptionProvider() {
+        return Arrays.asList(
+            Arguments.of(Errors.UNKNOWN_TOPIC_OR_PARTITION, false),
+            Arguments.of(Errors.INVALID_TOPIC_EXCEPTION, false),
+            Arguments.of(Errors.UNKNOWN_SERVER_ERROR, false),
+            Arguments.of(Errors.NETWORK_EXCEPTION, true),
+            Arguments.of(Errors.NONE, false));
+    }
+}


### PR DESCRIPTION
This is the implementation of the TopicMetadataRequestManager, responsible for handling topic metadata from `partitionsFor` and `listTopics`

The PR also refactors the current callback mechanism because I think the usage is rather inorganic.  Now, user can pass in a BiConsumer to be triggered when the request is completed.

@kirktrue @lianetm 
