### PR TITLE
KAFKA-14274, #7: introduce FetchRequestManager to integrate fetch into new consumer threading refactor

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -109,10 +109,10 @@
 
     <!-- Clients tests -->
     <suppress checks="ClassDataAbstractionCoupling"
-              files="(Sender|Fetcher|OffsetFetcher|KafkaConsumer|PrototypeAsyncConsumer|Metrics|RequestResponse|TransactionManager|KafkaAdminClient|Message|KafkaProducer)Test.java"/>
+              files="(Sender|Fetcher|FetchRequestManager|OffsetFetcher|KafkaConsumer|PrototypeAsyncConsumer|Metrics|RequestResponse|TransactionManager|KafkaAdminClient|Message|KafkaProducer)Test.java"/>
 
     <suppress checks="ClassFanOutComplexity"
-              files="(ConsumerCoordinator|KafkaConsumer|RequestResponse|Fetcher|KafkaAdminClient|Message|KafkaProducer)Test.java"/>
+              files="(ConsumerCoordinator|KafkaConsumer|RequestResponse|Fetcher|FetchRequestManager|KafkaAdminClient|Message|KafkaProducer)Test.java"/>
 
     <suppress checks="ClassFanOutComplexity"
               files="MockAdminClient.java"/>
@@ -121,7 +121,7 @@
               files="(OffsetFetcher|RequestResponse)Test.java"/>
 
     <suppress checks="JavaNCSS"
-              files="RequestResponseTest.java|FetcherTest.java|KafkaAdminClientTest.java"/>
+              files="RequestResponseTest.java|FetcherTest.java|FetchRequestManagerTest.java|KafkaAdminClientTest.java"/>
 
     <suppress checks="NPathComplexity"
               files="MemoryRecordsTest|MetricsTest|RequestResponseTest|TestSslUtils|AclAuthorizerBenchmark"/>

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThread.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThread.java
@@ -41,29 +41,29 @@ import java.util.function.Supplier;
  * It holds a reference to the {@link SubscriptionState}, which is
  * initialized by the polling thread.
  */
-public class DefaultBackgroundThread extends KafkaThread implements Closeable {
+public class DefaultBackgroundThread<K, V> extends KafkaThread implements Closeable {
 
     private static final long MAX_POLL_TIMEOUT_MS = 5000;
     private static final String BACKGROUND_THREAD_NAME = "consumer_background_thread";
     private final Time time;
     private final Logger log;
     private final BlockingQueue<ApplicationEvent> applicationEventQueue;
-    private final Supplier<ApplicationEventProcessor> applicationEventProcessorSupplier;
+    private final Supplier<ApplicationEventProcessor<K, V>> applicationEventProcessorSupplier;
     private final Supplier<NetworkClientDelegate> networkClientDelegateSupplier;
-    private final Supplier<RequestManagers> requestManagersSupplier;
+    private final Supplier<RequestManagers<K, V>> requestManagersSupplier;
     // empty if groupId is null
-    private ApplicationEventProcessor applicationEventProcessor;
+    private ApplicationEventProcessor<K, V> applicationEventProcessor;
     private NetworkClientDelegate networkClientDelegate;
-    private RequestManagers requestManagers;
+    private RequestManagers<K, V> requestManagers;
     private volatile boolean running;
     private final IdempotentCloser closer = new IdempotentCloser();
 
     public DefaultBackgroundThread(Time time,
                                    LogContext logContext,
                                    BlockingQueue<ApplicationEvent> applicationEventQueue,
-                                   Supplier<ApplicationEventProcessor> applicationEventProcessorSupplier,
+                                   Supplier<ApplicationEventProcessor<K, V>> applicationEventProcessorSupplier,
                                    Supplier<NetworkClientDelegate> networkClientDelegateSupplier,
-                                   Supplier<RequestManagers> requestManagersSupplier) {
+                                   Supplier<RequestManagers<K, V>> requestManagersSupplier) {
         super(BACKGROUND_THREAD_NAME, true);
         this.time = time;
         this.log = logContext.logger(getClass());

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultEventHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultEventHandler.java
@@ -36,27 +36,27 @@ import java.util.function.Supplier;
  * An {@link EventHandler} that uses a single background thread to consume {@link ApplicationEvent} and produce
  * {@link BackgroundEvent} from the {@link DefaultBackgroundThread}.
  */
-public class DefaultEventHandler implements EventHandler {
+public class DefaultEventHandler<K, V> implements EventHandler {
 
     private final Logger log;
     private final Time time;
     private final BlockingQueue<ApplicationEvent> applicationEventQueue;
     private final BlockingQueue<BackgroundEvent> backgroundEventQueue;
-    private final DefaultBackgroundThread backgroundThread;
+    private final DefaultBackgroundThread<K, V> backgroundThread;
     private final IdempotentCloser closer = new IdempotentCloser();
 
     public DefaultEventHandler(final Time time,
                                final LogContext logContext,
                                final BlockingQueue<ApplicationEvent> applicationEventQueue,
                                final BlockingQueue<BackgroundEvent> backgroundEventQueue,
-                               final Supplier<ApplicationEventProcessor> applicationEventProcessorSupplier,
+                               final Supplier<ApplicationEventProcessor<K, V>> applicationEventProcessorSupplier,
                                final Supplier<NetworkClientDelegate> networkClientDelegateSupplier,
-                               final Supplier<RequestManagers> requestManagersSupplier) {
+                               final Supplier<RequestManagers<K, V>> requestManagersSupplier) {
         this.log = logContext.logger(DefaultEventHandler.class);
         this.time = time;
         this.applicationEventQueue = applicationEventQueue;
         this.backgroundEventQueue = backgroundEventQueue;
-        this.backgroundThread = new DefaultBackgroundThread(time,
+        this.backgroundThread = new DefaultBackgroundThread<>(time,
                 logContext,
                 applicationEventQueue,
                 applicationEventProcessorSupplier,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetchRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetchRequestManager.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer.internals;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+import java.util.function.BiConsumer;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.clients.ClientResponse;
+import org.apache.kafka.clients.FetchSessionHandler;
+import org.apache.kafka.clients.consumer.internals.NetworkClientDelegate.PollResult;
+import org.apache.kafka.clients.consumer.internals.NetworkClientDelegate.UnsentRequest;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.requests.FetchRequest;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.Timer;
+import org.apache.kafka.common.utils.Utils;
+import org.slf4j.Logger;
+
+/**
+ * {@code FetchRequestManager} is responsible for generating {@link FetchRequest} that represent the
+ * {@link SubscriptionState#fetchablePartitions(Predicate)} based on the user's topic subscription/partition
+ * assignment.
+ *
+ * @param <K> Record key type
+ * @param <V> Record value type
+ */
+public class FetchRequestManager<K, V> extends AbstractFetch<K, V> implements RequestManager {
+
+    private final Logger log;
+    private final ErrorEventHandler errorEventHandler;
+
+    FetchRequestManager(final LogContext logContext,
+                        final Time time,
+                        final ErrorEventHandler errorEventHandler,
+                        final ConsumerMetadata metadata,
+                        final SubscriptionState subscriptions,
+                        final FetchConfig<K, V> fetchConfig,
+                        final FetchMetricsManager metricsManager,
+                        final NodeStatusDetector nodeStatusDetector) {
+        super(logContext, nodeStatusDetector, metadata, subscriptions, fetchConfig, metricsManager, time);
+        this.log = logContext.logger(FetchRequestManager.class);
+        this.errorEventHandler = errorEventHandler;
+    }
+
+    @Override
+    public PollResult poll(long currentTimeMs) {
+        log.debug("poll - currentTimeMs: {}", currentTimeMs);
+
+        List<UnsentRequest> requests;
+
+        if (!idempotentCloser.isClosed()) {
+            // If the fetcher is open (i.e. not closed), we will issue the normal fetch requests
+            requests = prepareFetchRequests().entrySet().stream().map(entry -> {
+                final Node fetchTarget = entry.getKey();
+                final FetchSessionHandler.FetchRequestData data = entry.getValue();
+                final FetchRequest.Builder request = createFetchRequest(fetchTarget, data);
+                final BiConsumer<ClientResponse, Throwable> responseHandler = (clientResponse, t) -> {
+                    if (t != null) {
+                        handleFetchResponse(fetchTarget, t);
+                        log.warn("Attempt to fetch data from node {} failed due to fatal exception", fetchTarget, t);
+                        errorEventHandler.handle(t);
+                    } else {
+                        handleFetchResponse(fetchTarget, data, clientResponse);
+                    }
+                };
+
+                return new UnsentRequest(request, fetchTarget, responseHandler);
+            }).collect(Collectors.toList());
+        } else {
+            requests = prepareCloseFetchSessionRequests().entrySet().stream().map(entry -> {
+                final Node fetchTarget = entry.getKey();
+                final FetchSessionHandler.FetchRequestData data = entry.getValue();
+                final FetchRequest.Builder request = createFetchRequest(fetchTarget, data);
+                final BiConsumer<ClientResponse, Throwable> responseHandler = (clientResponse, t) -> {
+                    if (t != null) {
+                        handleCloseFetchSessionResponse(fetchTarget, data, t);
+                        log.warn("Attempt to close fetch session on node {} failed due to fatal exception", fetchTarget, t);
+                        errorEventHandler.handle(t);
+                    } else {
+                        handleCloseFetchSessionResponse(fetchTarget, data);
+                    }
+                };
+
+                return new UnsentRequest(request, fetchTarget, responseHandler);
+            }).collect(Collectors.toList());
+        }
+
+        return new PollResult(Long.MAX_VALUE, requests);
+    }
+
+    /**
+     * Drains any of the {@link CompletedFetch} objects from the internal buffer to the returned {@link Queue}.
+     *
+     * <p/>
+     *
+     * This is used by the {@link org.apache.kafka.clients.consumer.internals.events.ApplicationEventProcessor} to
+     * pull off any fetch results that are stored in the background thread to provide them to the application thread.
+     *
+     * @return {@link Queue} containing zero or more {@link CompletedFetch}
+     */
+    public Queue<CompletedFetch<K, V>> drain() {
+        Queue<CompletedFetch<K, V>> q = new LinkedList<>();
+        CompletedFetch<K, V> completedFetch = fetchBuffer.poll();
+
+        while (completedFetch != null) {
+            q.add(completedFetch);
+            completedFetch = fetchBuffer.poll();
+        }
+
+        return q;
+    }
+
+    @Override
+    protected void closeInternal(Timer timer) {
+        // We can't clear out the session handlers just yet as we need them for the next poll to send the
+        // 'close fetch session' requests.
+        Utils.closeQuietly(decompressionBufferSupplier, "decompressionBufferSupplier");
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/FetchEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/FetchEvent.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer.internals.events;
+
+import org.apache.kafka.clients.consumer.internals.CompletedFetch;
+
+import java.util.Queue;
+
+/**
+ * This event signals the background thread to submit a fetch request.
+ */
+public class FetchEvent<K, V> extends CompletableApplicationEvent<Queue<CompletedFetch<K, V>>> {
+
+    public FetchEvent() {
+        super(Type.FETCH);
+    }
+
+    @Override
+    public String toString() {
+        return "FetchEvent{" +
+                "future=" + future +
+                ", type=" + type +
+                '}';
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThreadTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThreadTest.java
@@ -58,11 +58,11 @@ public class DefaultBackgroundThreadTest {
     private ConsumerMetadata metadata;
     private NetworkClientDelegate networkClient;
     private BlockingQueue<ApplicationEvent> applicationEventsQueue;
-    private ApplicationEventProcessor applicationEventProcessor;
+    private ApplicationEventProcessor<String, String> applicationEventProcessor;
     private CoordinatorRequestManager coordinatorManager;
     private CommitRequestManager commitManager;
     private TopicMetadataRequestManager topicMetadataRequestManager;
-    private DefaultBackgroundThread backgroundThread;
+    private DefaultBackgroundThread<String, String> backgroundThread;
 
     @BeforeEach
     public void setup() {


### PR DESCRIPTION
This change introduces the `FetchRequestManager` that will be responsible for:

- Formatting fetch requests to the background thread
- Configuring the callback on fetch responses for the background thread

The response handler will collect the fetch responses from the broker and create `CompletedFetch` instances as is done in `Fetcher`. However, unlike the `Fetcher`, the foreground logic will decompress/deserialize/and convert the data in `CompletedFetch` before returning to the user.