### PR TITLE
Kafka-14965 - ListOffsetsRequestManager implementation

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/Metadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/Metadata.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.clients;
 
 import org.apache.kafka.common.Cluster;
+import org.apache.kafka.common.ClusterResourceListener;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
@@ -200,6 +201,10 @@ public class Metadata implements Closeable {
      */
     public synchronized boolean updateRequested() {
         return this.needFullUpdate || this.needPartialUpdate;
+    }
+
+    public synchronized void addClusterUpdateListener(ClusterResourceListener listener) {
+        this.clusterResourceListeners.maybeAdd(listener);
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThread.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThread.java
@@ -41,6 +41,7 @@ import java.util.concurrent.BlockingQueue;
 
 import static org.apache.kafka.clients.consumer.internals.Utils.CONSUMER_MAX_INFLIGHT_REQUESTS_PER_CONNECTION;
 import static org.apache.kafka.clients.consumer.internals.Utils.CONSUMER_METRIC_GROUP_PREFIX;
+import static org.apache.kafka.clients.consumer.internals.Utils.getConfiguredIsolationLevel;
 
 /**
  * Background thread runnable that consumes {@code ApplicationEvent} and
@@ -158,7 +159,7 @@ public class DefaultBackgroundThread extends KafkaThread {
                         new ListOffsetsRequestManager(
                                 subscriptionState,
                                 metadata,
-                                config,
+                                getConfiguredIsolationLevel(config),
                                 time,
                                 apiVersions,
                                 logContext);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ListOffsetsRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ListOffsetsRequestManager.java
@@ -1,0 +1,347 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer.internals;
+
+import org.apache.kafka.clients.ApiVersions;
+import org.apache.kafka.clients.Metadata;
+import org.apache.kafka.clients.StaleMetadataException;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.internals.OffsetFetcherUtils.ListOffsetData;
+import org.apache.kafka.clients.consumer.internals.OffsetFetcherUtils.ListOffsetResult;
+import org.apache.kafka.common.ClusterResource;
+import org.apache.kafka.common.ClusterResourceListener;
+import org.apache.kafka.common.IsolationLevel;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.message.ListOffsetsRequestData;
+import org.apache.kafka.common.requests.ListOffsetsRequest;
+import org.apache.kafka.common.requests.ListOffsetsResponse;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.Time;
+import org.slf4j.Logger;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Build requests for retrieving partition offsets from partition leaders (see
+ * {@link #fetchOffsets(Set, long, boolean)}). Requests are kept in-memory
+ * ready to be sent on the next call to {@link #poll(long)}.
+ * <p>
+ * Partition leadership information required to build the requests is retrieved from the
+ * {@link ConsumerMetadata}, so this implements {@link ClusterResourceListener} to get notified
+ * when the cluster metadata is updated.
+ */
+public class ListOffsetsRequestManager implements RequestManager, ClusterResourceListener {
+
+    private final ConsumerMetadata metadata;
+    private final IsolationLevel isolationLevel;
+    private final Logger log;
+    private final OffsetFetcherUtils offsetFetcherUtils;
+
+    private final List<ListOffsetsRequestState> requestsToRetry = Collections.synchronizedList(new ArrayList<>());
+    private final List<NetworkClientDelegate.UnsentRequest> pendingRequests =
+            Collections.synchronizedList(new ArrayList<>());
+
+    public ListOffsetsRequestManager(final SubscriptionState subscriptionState,
+                                     final ConsumerMetadata metadata,
+                                     final ConsumerConfig config,
+                                     final Time time,
+                                     final ApiVersions apiVersions,
+                                     final LogContext logContext) {
+        requireNonNull(subscriptionState);
+        requireNonNull(metadata);
+        requireNonNull(config);
+        requireNonNull(time);
+        requireNonNull(apiVersions);
+        requireNonNull(logContext);
+
+        this.metadata = metadata;
+        this.metadata.addClusterUpdateListener(this);
+        String isolationLevelStr = config.getString(ConsumerConfig.ISOLATION_LEVEL_CONFIG);
+        this.isolationLevel = IsolationLevel.valueOf(((isolationLevelStr == null) ?
+                ConsumerConfig.DEFAULT_ISOLATION_LEVEL : isolationLevelStr).toUpperCase(Locale.ROOT));
+        this.log = logContext.logger(getClass());
+        this.offsetFetcherUtils = new OffsetFetcherUtils(logContext, metadata, subscriptionState,
+                time, apiVersions);
+
+    }
+
+    /**
+     * Determine if a there are pending fetch offsets requests to be sent and build a
+     * {@link org.apache.kafka.clients.consumer.internals.NetworkClientDelegate.PollResult}
+     * containing it.
+     */
+    @Override
+    public NetworkClientDelegate.PollResult poll(final long currentTimeMs) {
+        List<NetworkClientDelegate.UnsentRequest> requestsToSend;
+        synchronized (pendingRequests) {
+            requestsToSend = new ArrayList<>(pendingRequests);
+            pendingRequests.clear();
+        }
+        if (requestsToSend.isEmpty()) {
+            return new NetworkClientDelegate.PollResult(Long.MAX_VALUE, Collections.emptyList());
+        }
+
+        return new NetworkClientDelegate.PollResult(Long.MAX_VALUE,
+                Collections.unmodifiableList(requestsToSend));
+    }
+
+    /**
+     * Retrieve offsets for the given partitions and timestamp. This will build multiple requests (one for each
+     * node that is leader of some of the partitions involved), add them to the list of
+     * `pendingRequests` ready to be sent on the next call to {@link #poll(long)} and compute an
+     * aggregated result.
+     *
+     * @param partitions        Partitions to get offsets for
+     * @param timestamp         Target time
+     * @param requireTimestamps True if this should fail with an UnsupportedVersionException if
+     *                          the broker does not support fetching precise timestamps for offsets
+     * @return Future containing the map of offsets retrieved for each partition. The future will
+     * complete when the responses for the requests are received and processed following a call
+     * to {@link #poll(long)}
+     */
+    public CompletableFuture<Map<TopicPartition, Long>> fetchOffsets(final Set<TopicPartition> partitions,
+                                                                     long timestamp,
+                                                                     boolean requireTimestamps) {
+        if (partitions.isEmpty()) {
+            return CompletableFuture.completedFuture(Collections.emptyMap());
+        }
+        metadata.addTransientTopics(offsetFetcherUtils.topicsForPartitions(partitions));
+
+        Map<TopicPartition, Long> timestampsToSearch = partitions.stream()
+                .collect(Collectors.toMap(Function.identity(), tp -> timestamp));
+        ListOffsetsRequestState requestState = new ListOffsetsRequestState(timestampsToSearch,
+                requireTimestamps, offsetFetcherUtils, isolationLevel);
+        requestState.globalResult.whenComplete((result, error) -> metadata.clearTransientTopics());
+
+        fetchOffsetsByTimes(timestampsToSearch, requireTimestamps, requestState);
+
+        return requestState.globalResult;
+    }
+
+    /**
+     * Generate requests for partitions with known leaders. Update the requestState by adding
+     * partitions with unknown leader to the requestState.remainingToSearch
+     */
+    private void fetchOffsetsByTimes(Map<TopicPartition, Long> timestampsToSearch,
+                                     boolean requireTimestamps,
+                                     ListOffsetsRequestState requestState) {
+
+        Map<TopicPartition, Long> remainingToSearch = new HashMap<>(timestampsToSearch);
+
+        List<NetworkClientDelegate.UnsentRequest> unsentRequests =
+                sendListOffsetsRequests(remainingToSearch, requireTimestamps, requestState);
+
+        if (!requestState.remainingToSearch.isEmpty()) {
+            requestsToRetry.add(requestState);
+        }
+        pendingRequests.addAll(unsentRequests);
+    }
+
+    @Override
+    public void onUpdate(ClusterResource clusterResource) {
+        // Cluster metadata has been updated. Retry any request that is waiting to be built or retried.
+        List<ListOffsetsRequestState> requestsToProcess;
+        synchronized (requestsToRetry) {
+            requestsToProcess = new ArrayList<>(requestsToRetry);
+            requestsToRetry.clear();
+        }
+        requestsToProcess.forEach(requestState -> fetchOffsetsByTimes(requestState.remainingToSearch, requestState.requireTimestamps,
+                requestState));
+    }
+
+    /**
+     * Search the offsets by target times for the specified partitions.
+     *
+     * @param timestampsToSearch the mapping between partitions and target time
+     * @param requireTimestamps  true if we should fail with an UnsupportedVersionException if the broker does
+     *                           not support fetching precise timestamps for offsets
+     * @return A list of
+     * {@link org.apache.kafka.clients.consumer.internals.NetworkClientDelegate.UnsentRequest}
+     * that can be polled to obtain the corresponding timestamps and offsets.
+     */
+    private List<NetworkClientDelegate.UnsentRequest> sendListOffsetsRequests(
+            final Map<TopicPartition, Long> timestampsToSearch,
+            final boolean requireTimestamps,
+            final ListOffsetsRequestState requestState) {
+        final List<NetworkClientDelegate.UnsentRequest> unsentRequests = new ArrayList<>();
+        Map<Node, Map<TopicPartition, ListOffsetsRequestData.ListOffsetsPartition>> timestampsToSearchByNode =
+                groupListOffsetRequests(timestampsToSearch, requestState);
+        if (timestampsToSearchByNode.isEmpty()) {
+            throw new StaleMetadataException();
+        }
+        MultiNodeRequest multiNodeRequest = new MultiNodeRequest(timestampsToSearchByNode.size());
+        requestState.addMultiNodeRequest(multiNodeRequest);
+
+        for (Map.Entry<Node, Map<TopicPartition, ListOffsetsRequestData.ListOffsetsPartition>> entry : timestampsToSearchByNode.entrySet()) {
+            Node node = entry.getKey();
+            ListOffsetsRequest.Builder builder = ListOffsetsRequest.Builder
+                    .forConsumer(requireTimestamps, isolationLevel, false)
+                    .setTargetTimes(ListOffsetsRequest.toListOffsetsTopics(entry.getValue()));
+
+            log.debug("Sending ListOffsetRequest {} to broker {}", builder, node);
+
+            NetworkClientDelegate.UnsentRequest unsentRequest = new NetworkClientDelegate.UnsentRequest(
+                    builder,
+                    Optional.ofNullable(node));
+            unsentRequests.add(unsentRequest);
+            unsentRequest.future().whenComplete((response, error) -> {
+                if (error != null) {
+                    log.error("Sending ListOffsetRequest {} to broker {} failed",
+                            builder,
+                            node,
+                            error);
+                    multiNodeRequest.resultFuture.completeExceptionally(error);
+                } else {
+                    ListOffsetsResponse lor = (ListOffsetsResponse) response.responseBody();
+                    log.trace("Received ListOffsetResponse {} from broker {}", lor, node);
+                    onSendToNodeSuccess(lor, multiNodeRequest);
+                }
+            });
+        }
+        return unsentRequests;
+    }
+
+    private void onSendToNodeSuccess(final ListOffsetsResponse response,
+                                     final MultiNodeRequest multiNodeRequest) {
+        try {
+            ListOffsetResult partialResult = offsetFetcherUtils.handleListOffsetResponse(response);
+            multiNodeRequest.fetchedTimestampOffsets.putAll(partialResult.fetchedOffsets);
+            multiNodeRequest.partitionsToRetry.addAll(partialResult.partitionsToRetry);
+
+            if (multiNodeRequest.expectedResponses.decrementAndGet() == 0) {
+                ListOffsetResult result =
+                        new ListOffsetResult(multiNodeRequest.fetchedTimestampOffsets,
+                                multiNodeRequest.partitionsToRetry);
+                multiNodeRequest.resultFuture.complete(result);
+            }
+        } catch (RuntimeException e) {
+            multiNodeRequest.resultFuture.completeExceptionally(e);
+        }
+    }
+
+    private static class ListOffsetsRequestState {
+
+        private final Map<TopicPartition, ListOffsetData> fetchedOffsets;
+        private final Map<TopicPartition, Long> remainingToSearch;
+        private final List<MultiNodeRequest> multiNodeRequests;
+        private final CompletableFuture<Map<TopicPartition, Long>> globalResult;
+        final boolean requireTimestamps;
+        final OffsetFetcherUtils offsetFetcherUtils;
+        final IsolationLevel isolationLevel;
+
+        private ListOffsetsRequestState(Map<TopicPartition, Long> timestampsToSearch,
+                                        boolean requireTimestamps,
+                                        OffsetFetcherUtils offsetFetcherUtils,
+                                        IsolationLevel isolationLevel) {
+            remainingToSearch = Collections.synchronizedMap(timestampsToSearch);
+            fetchedOffsets = Collections.synchronizedMap(new HashMap<>());
+            multiNodeRequests = Collections.synchronizedList(new ArrayList<>());
+            globalResult = new CompletableFuture<>();
+            this.requireTimestamps = requireTimestamps;
+            this.offsetFetcherUtils = offsetFetcherUtils;
+            this.isolationLevel = isolationLevel;
+        }
+
+        void addMultiNodeRequest(MultiNodeRequest multiNodeRequest) {
+            multiNodeRequest.resultFuture.whenComplete((multiNodeResult, error) -> {
+                // Done sending request to a set of known leaders
+                multiNodeRequests.remove(multiNodeRequest);
+                if (error == null) {
+                    fetchedOffsets.putAll(multiNodeResult.fetchedOffsets);
+                    remainingToSearch.keySet().retainAll(multiNodeResult.partitionsToRetry);
+                    offsetFetcherUtils.updateSubscriptionState(
+                            multiNodeResult.fetchedOffsets,
+                            isolationLevel);
+
+                    if (remainingToSearch.size() == 0) {
+                        ListOffsetResult listOffsetResult = new ListOffsetResult(fetchedOffsets,
+                                remainingToSearch.keySet());
+                        globalResult.complete(listOffsetResult.offsetAndMetadataMap());
+                    }
+                } else {
+                    // TODO: check if retriable errors should be considered/retried here
+                    globalResult.completeExceptionally(error);
+                }
+            });
+
+            multiNodeRequests.add(multiNodeRequest);
+        }
+    }
+
+    private static class MultiNodeRequest {
+        private final Map<TopicPartition, ListOffsetData> fetchedTimestampOffsets;
+        private final Set<TopicPartition> partitionsToRetry;
+        private final AtomicInteger expectedResponses;
+        private final CompletableFuture<ListOffsetResult> resultFuture;
+
+        private MultiNodeRequest(int nodeCount) {
+            fetchedTimestampOffsets = Collections.synchronizedMap(new HashMap<>());
+            partitionsToRetry = Collections.synchronizedSet(new HashSet<>());
+            expectedResponses = new AtomicInteger(nodeCount);
+            resultFuture = new CompletableFuture<>();
+        }
+    }
+
+    /**
+     * Group partitions by leader. Topic partitions from `timestampsToSearch` for which
+     * the leader is not known are kept as `remainingToSearch` in the `requestState`
+     *
+     * @param timestampsToSearch The mapping from partitions to the target timestamps
+     * @param requestState       Request state that will be extended by adding to its
+     *                           `remainingToSearch` map all partitions for which the
+     *                           request cannot be performed due to unknown leader (need
+     *                           metadata update)
+     */
+    private Map<Node, Map<TopicPartition, ListOffsetsRequestData.ListOffsetsPartition>> groupListOffsetRequests(
+            Map<TopicPartition, Long> timestampsToSearch,
+            final ListOffsetsRequestState requestState) {
+        final Map<TopicPartition, ListOffsetsRequestData.ListOffsetsPartition> partitionDataMap = new HashMap<>();
+        for (Map.Entry<TopicPartition, Long> entry : timestampsToSearch.entrySet()) {
+            TopicPartition tp = entry.getKey();
+            Long offset = entry.getValue();
+            Metadata.LeaderAndEpoch leaderAndEpoch = metadata.currentLeader(tp);
+
+            if (!leaderAndEpoch.leader.isPresent()) {
+                log.debug("Leader for partition {} is unknown for fetching offset {}", tp, offset);
+                metadata.requestUpdate();
+                requestState.remainingToSearch.put(tp, offset);
+            } else {
+                int currentLeaderEpoch = leaderAndEpoch.epoch.orElse(ListOffsetsResponse.UNKNOWN_EPOCH);
+                partitionDataMap.put(tp, new ListOffsetsRequestData.ListOffsetsPartition()
+                        .setPartitionIndex(tp.partition())
+                        .setTimestamp(offset)
+                        .setCurrentLeaderEpoch(currentLeaderEpoch));
+            }
+        }
+        return offsetFetcherUtils.regroupPartitionMapByNode(partitionDataMap);
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ListOffsetsRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ListOffsetsRequestManager.java
@@ -89,7 +89,6 @@ public class ListOffsetsRequestManager implements RequestManager, ClusterResourc
         this.requestsToSend = new ArrayList<>();
         this.offsetFetcherUtils = new OffsetFetcherUtils(logContext, metadata, subscriptionState,
                 time, apiVersions);
-
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ListOffsetsRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ListOffsetsRequestManager.java
@@ -199,7 +199,7 @@ public class ListOffsetsRequestManager implements RequestManager, ClusterResourc
                     .forConsumer(requireTimestamps, isolationLevel, false)
                     .setTargetTimes(ListOffsetsRequest.toListOffsetsTopics(entry.getValue()));
 
-            log.debug("Sending ListOffsetRequest {} to broker {}", builder, node);
+            log.debug("Creating ListOffsetRequest {} for broker {}", builder, node);
 
             NetworkClientDelegate.UnsentRequest unsentRequest = new NetworkClientDelegate.UnsentRequest(
                     builder,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumer.java
@@ -410,18 +410,7 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
                 partitions.stream().collect(Collectors.toSet()),
                 timestamp,
                 false);
-        eventHandler.add(listOffsetsEvent);
-        try {
-            return listOffsetsEvent.future().get(timeout.toMillis(), TimeUnit.MILLISECONDS);
-        } catch (InterruptedException e) {
-            throw new InterruptException(e);
-        } catch (TimeoutException e) {
-            throw new org.apache.kafka.common.errors.TimeoutException(e);
-        } catch (ExecutionException e) {
-            throw new KafkaException(e);
-        } catch (Exception e) {
-            throw e;
-        }
+        return eventHandler.addAndGet(listOffsetsEvent, timeout);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumer.java
@@ -31,6 +31,7 @@ import org.apache.kafka.clients.consumer.OffsetCommitCallback;
 import org.apache.kafka.clients.consumer.internals.events.BackgroundEvent;
 import org.apache.kafka.clients.consumer.internals.events.CommitApplicationEvent;
 import org.apache.kafka.clients.consumer.internals.events.EventHandler;
+import org.apache.kafka.clients.consumer.internals.events.ListOffsetsApplicationEvent;
 import org.apache.kafka.clients.consumer.internals.events.MetadataUpdateApplicationEvent;
 import org.apache.kafka.clients.consumer.internals.events.OffsetFetchApplicationEvent;
 import org.apache.kafka.clients.consumer.internals.events.UnsubscribeApplicationEvent;
@@ -44,6 +45,7 @@ import org.apache.kafka.common.errors.InterruptException;
 import org.apache.kafka.common.errors.InvalidGroupIdException;
 import org.apache.kafka.common.internals.ClusterResourceListeners;
 import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.requests.ListOffsetsRequest;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
@@ -67,7 +69,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
+import static java.util.Objects.requireNonNull;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG;
 import static org.apache.kafka.clients.consumer.internals.Utils.createLogContext;
@@ -377,22 +381,44 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
 
     @Override
     public Map<TopicPartition, Long> beginningOffsets(Collection<TopicPartition> partitions) {
-        throw new KafkaException("method not implemented");
+        return beginningOffsets(partitions, Duration.ofMillis(defaultApiTimeoutMs));
     }
 
     @Override
     public Map<TopicPartition, Long> beginningOffsets(Collection<TopicPartition> partitions, Duration timeout) {
-        throw new KafkaException("method not implemented");
+        return beginningOrEndOffset(partitions, ListOffsetsRequest.EARLIEST_TIMESTAMP, timeout);
     }
 
     @Override
     public Map<TopicPartition, Long> endOffsets(Collection<TopicPartition> partitions) {
-        throw new KafkaException("method not implemented");
+        return endOffsets(partitions, Duration.ofMillis(defaultApiTimeoutMs));
     }
 
     @Override
     public Map<TopicPartition, Long> endOffsets(Collection<TopicPartition> partitions, Duration timeout) {
-        throw new KafkaException("method not implemented");
+        return beginningOrEndOffset(partitions, ListOffsetsRequest.LATEST_TIMESTAMP, timeout);
+    }
+
+    private Map<TopicPartition, Long> beginningOrEndOffset(Collection<TopicPartition> partitions,
+                                                           Long timestamp,
+                                                           Duration timeout) {
+        requireNonNull(partitions, "Partitions cannot be null");
+        final ListOffsetsApplicationEvent listOffsetsEvent = new ListOffsetsApplicationEvent(
+                partitions.stream().collect(Collectors.toSet()),
+                timestamp,
+                false);
+        eventHandler.add(listOffsetsEvent);
+        try {
+            return listOffsetsEvent.future().get(timeout.toMillis(), TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            throw new InterruptException(e);
+        } catch (TimeoutException e) {
+            throw new org.apache.kafka.common.errors.TimeoutException(e);
+        } catch (ExecutionException e) {
+            throw new KafkaException(e);
+        } catch (Exception e) {
+            throw e;
+        }
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumer.java
@@ -400,9 +400,12 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
     }
 
     private Map<TopicPartition, Long> beginningOrEndOffset(Collection<TopicPartition> partitions,
-                                                           Long timestamp,
+                                                           long timestamp,
                                                            Duration timeout) {
         requireNonNull(partitions, "Partitions cannot be null");
+        if (partitions.isEmpty()) {
+            return Collections.emptyMap();
+        }
         final ListOffsetsApplicationEvent listOffsetsEvent = new ListOffsetsApplicationEvent(
                 partitions.stream().collect(Collectors.toSet()),
                 timestamp,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestManagers.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestManagers.java
@@ -30,17 +30,25 @@ public class RequestManagers {
 
     public final Optional<CoordinatorRequestManager> coordinatorRequestManager;
     public final Optional<CommitRequestManager> commitRequestManager;
+    public final Optional<ListOffsetsRequestManager> listOffsetsRequestManager;
     private final List<Optional<? extends RequestManager>> entries;
 
     public RequestManagers(Optional<CoordinatorRequestManager> coordinatorRequestManager,
-                           Optional<CommitRequestManager> commitRequestManager) {
+                           Optional<CommitRequestManager> commitRequestManager,
+                           Optional<ListOffsetsRequestManager> listOffsetsRequestManager) {
         this.coordinatorRequestManager = coordinatorRequestManager;
         this.commitRequestManager = commitRequestManager;
+        this.listOffsetsRequestManager = listOffsetsRequestManager;
 
         List<Optional<? extends RequestManager>> list = new ArrayList<>();
         list.add(coordinatorRequestManager);
         list.add(commitRequestManager);
+        list.add(listOffsetsRequestManager);
         entries = Collections.unmodifiableList(list);
+    }
+
+    public RequestManagers() {
+        this(Optional.empty(), Optional.empty(), Optional.empty());
     }
 
     public List<Optional<? extends RequestManager>> entries() {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestManagers.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestManagers.java
@@ -21,6 +21,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * {@code RequestManagers} provides a means to pass around the set of {@link RequestManager} instances in the system.
  * This allows callers to both use the specific {@link RequestManager} instance, or to iterate over the list via
@@ -30,25 +32,23 @@ public class RequestManagers {
 
     public final Optional<CoordinatorRequestManager> coordinatorRequestManager;
     public final Optional<CommitRequestManager> commitRequestManager;
-    public final Optional<ListOffsetsRequestManager> listOffsetsRequestManager;
+    public final ListOffsetsRequestManager listOffsetsRequestManager;
     private final List<Optional<? extends RequestManager>> entries;
 
-    public RequestManagers(Optional<CoordinatorRequestManager> coordinatorRequestManager,
-                           Optional<CommitRequestManager> commitRequestManager,
-                           Optional<ListOffsetsRequestManager> listOffsetsRequestManager) {
+    public RequestManagers(ListOffsetsRequestManager listOffsetsRequestManager,
+                           Optional<CoordinatorRequestManager> coordinatorRequestManager,
+                           Optional<CommitRequestManager> commitRequestManager) {
+        this.listOffsetsRequestManager = requireNonNull(listOffsetsRequestManager,
+                "ListOffsetsRequestManager cannot be null");
         this.coordinatorRequestManager = coordinatorRequestManager;
         this.commitRequestManager = commitRequestManager;
-        this.listOffsetsRequestManager = listOffsetsRequestManager;
+
 
         List<Optional<? extends RequestManager>> list = new ArrayList<>();
         list.add(coordinatorRequestManager);
         list.add(commitRequestManager);
-        list.add(listOffsetsRequestManager);
+        list.add(Optional.of(listOffsetsRequestManager));
         entries = Collections.unmodifiableList(list);
-    }
-
-    public RequestManagers() {
-        this(Optional.empty(), Optional.empty(), Optional.empty());
     }
 
     public List<Optional<? extends RequestManager>> entries() {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEvent.java
@@ -25,6 +25,7 @@ public abstract class ApplicationEvent {
 
     public enum Type {
         NOOP, COMMIT, POLL, FETCH, FETCH_COMMITTED_OFFSET, METADATA_UPDATE, UNSUBSCRIBE,
+        LIST_OFFSETS,
     }
 
     protected final Type type;

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
@@ -18,7 +18,6 @@ package org.apache.kafka.clients.consumer.internals.events;
 
 import org.apache.kafka.clients.consumer.internals.CommitRequestManager;
 import org.apache.kafka.clients.consumer.internals.ConsumerMetadata;
-import org.apache.kafka.clients.consumer.internals.ListOffsetsRequestManager;
 import org.apache.kafka.clients.consumer.internals.RequestManagers;
 import org.apache.kafka.common.KafkaException;
 
@@ -128,14 +127,7 @@ public class ApplicationEventProcessor {
     }
 
     private boolean process(final ListOffsetsApplicationEvent event) {
-        if (!requestManagers.listOffsetsRequestManager.isPresent()) {
-            event.future().completeExceptionally(new KafkaException("Unable to list offsets " +
-                "because the ListOffsetsRequestManager is not available."));
-            return false;
-        }
-        ListOffsetsRequestManager listOffsetsRequestManager =
-                requestManagers.listOffsetsRequestManager.get();
-        listOffsetsRequestManager.fetchOffsets(event.partitions, event.timestamp,
+        requestManagers.listOffsetsRequestManager.fetchOffsets(event.partitions, event.timestamp,
                         event.requireTimestamps)
                 .whenComplete((result, error) -> {
                     if (error != null) {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ListOffsetsApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ListOffsetsApplicationEvent.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer.internals.events;
+
+import org.apache.kafka.common.TopicPartition;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Event for retrieving partition offsets from the partition leader
+ * by performing a {@link org.apache.kafka.common.requests.ListOffsetsRequest}
+ */
+public class ListOffsetsApplicationEvent extends ApplicationEvent {
+    private final CompletableFuture<Map<TopicPartition, Long>> future;
+
+    final Set<TopicPartition> partitions;
+    final long timestamp;
+    final boolean requireTimestamps;
+
+    public ListOffsetsApplicationEvent(final Set<TopicPartition> partitions,
+                                       long timestamp,
+                                       boolean requireTimestamps) {
+        super(Type.LIST_OFFSETS);
+        this.partitions = partitions;
+        this.timestamp = timestamp;
+        this.requireTimestamps = requireTimestamps;
+        this.future = new CompletableFuture<>();
+    }
+
+    public CompletableFuture<Map<TopicPartition, Long>> future() {
+        return future;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ListOffsetsApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ListOffsetsApplicationEvent.java
@@ -26,7 +26,7 @@ import java.util.concurrent.CompletableFuture;
  * Event for retrieving partition offsets from the partition leader
  * by performing a {@link org.apache.kafka.common.requests.ListOffsetsRequest}
  */
-public class ListOffsetsApplicationEvent extends ApplicationEvent {
+public class ListOffsetsApplicationEvent extends CompletableApplicationEvent<Map<TopicPartition, Long>> {
     private final CompletableFuture<Map<TopicPartition, Long>> future;
 
     final Set<TopicPartition> partitions;
@@ -45,5 +45,13 @@ public class ListOffsetsApplicationEvent extends ApplicationEvent {
 
     public CompletableFuture<Map<TopicPartition, Long>> future() {
         return future;
+    }
+
+    @Override
+    public String toString() {
+        return "ListOffsetsApplicationEvent {" +
+                "partitions=" + partitions + ", " +
+                "target timestamp=" + timestamp + ", " +
+                "requireTimestamps=" + requireTimestamps + '}';
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThreadTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThreadTest.java
@@ -62,10 +62,12 @@ public class DefaultBackgroundThreadTest {
     private MockTime time;
     private ConsumerMetadata metadata;
     private NetworkClientDelegate networkClient;
+    private SubscriptionState subscriptionState;
     private BlockingQueue<BackgroundEvent> backgroundEventsQueue;
     private BlockingQueue<ApplicationEvent> applicationEventsQueue;
     private ApplicationEventProcessor applicationEventProcessor;
     private CoordinatorRequestManager coordinatorManager;
+    private ListOffsetsRequestManager listOffsetsRequestManager;
     private ErrorEventHandler errorEventHandler;
     private int requestTimeoutMs = 500;
     private GroupState groupState;
@@ -77,10 +79,12 @@ public class DefaultBackgroundThreadTest {
         this.time = new MockTime(0);
         this.metadata = mock(ConsumerMetadata.class);
         this.networkClient = mock(NetworkClientDelegate.class);
+        this.subscriptionState = mock(SubscriptionState.class);
         this.applicationEventsQueue = (BlockingQueue<ApplicationEvent>) mock(BlockingQueue.class);
         this.backgroundEventsQueue = (BlockingQueue<BackgroundEvent>) mock(BlockingQueue.class);
         this.applicationEventProcessor = mock(ApplicationEventProcessor.class);
         this.coordinatorManager = mock(CoordinatorRequestManager.class);
+        this.listOffsetsRequestManager = mock(ListOffsetsRequestManager.class);
         this.errorEventHandler = mock(ErrorEventHandler.class);
         GroupRebalanceConfig rebalanceConfig = new GroupRebalanceConfig(
                 100,
@@ -183,7 +187,10 @@ public class DefaultBackgroundThreadTest {
     }
 
     private RequestManagers mockRequestManagers() {
-        return new RequestManagers(Optional.of(coordinatorManager), Optional.of(commitManager));
+        return new RequestManagers(
+                Optional.of(coordinatorManager),
+                Optional.of(commitManager),
+                Optional.of(listOffsetsRequestManager));
     }
 
     private static NetworkClientDelegate.UnsentRequest findCoordinatorUnsentRequest(
@@ -212,11 +219,13 @@ public class DefaultBackgroundThreadTest {
                 backgroundEventsQueue,
                 this.metadata,
                 this.networkClient,
+                this.subscriptionState,
                 this.groupState,
                 this.errorEventHandler,
                 applicationEventProcessor,
                 this.coordinatorManager,
-                this.commitManager);
+                this.commitManager,
+                this.listOffsetsRequestManager);
     }
 
     private NetworkClientDelegate.PollResult mockPollCoordinatorResult() {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThreadTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThreadTest.java
@@ -188,9 +188,9 @@ public class DefaultBackgroundThreadTest {
 
     private RequestManagers mockRequestManagers() {
         return new RequestManagers(
+                listOffsetsRequestManager,
                 Optional.of(coordinatorManager),
-                Optional.of(commitManager),
-                Optional.of(listOffsetsRequestManager));
+                Optional.of(commitManager));
     }
 
     private static NetworkClientDelegate.UnsentRequest findCoordinatorUnsentRequest(

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ListOffsetsRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ListOffsetsRequestManagerTest.java
@@ -25,6 +25,7 @@ import org.apache.kafka.common.IsolationLevel;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.TopicAuthorizationException;
 import org.apache.kafka.common.message.ListOffsetsResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
@@ -34,24 +35,32 @@ import org.apache.kafka.common.requests.ListOffsetsResponse;
 import org.apache.kafka.common.requests.RequestHeader;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
-import org.apache.kafka.common.utils.Time;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -62,8 +71,10 @@ public class ListOffsetsRequestManagerTest {
     private SubscriptionState subscriptionState;
     private MockTime time;
     private static final String TEST_TOPIC = "t1";
-    private static final int TEST_PARTITION = 1;
-    private static final Node LEADER_1 = new Node(0, "localhost", 9092);
+    private static final TopicPartition TEST_PARTITION_1 = new TopicPartition(TEST_TOPIC, 1);
+    private static final TopicPartition TEST_PARTITION_2 = new TopicPartition(TEST_TOPIC, 2);
+    private static final Node LEADER_1 = new Node(0, "host1", 9092);
+    private static final Node LEADER_2 = new Node(0, "host2", 9092);
     private static final IsolationLevel DEFAULT_ISOLATION_LEVEL = IsolationLevel.READ_COMMITTED;
 
     @BeforeEach
@@ -72,18 +83,17 @@ public class ListOffsetsRequestManagerTest {
         subscriptionState = mock(SubscriptionState.class);
         this.time = new MockTime(0);
         requestManager = new ListOffsetsRequestManager(subscriptionState,
-                metadata, DEFAULT_ISOLATION_LEVEL, mock(Time.class),
+                metadata, DEFAULT_ISOLATION_LEVEL, time,
                 mock(ApiVersions.class), new LogContext());
     }
 
     @Test
     public void testListOffsetsRequest_Success() throws ExecutionException, InterruptedException {
         Map<TopicPartition, Long> partitionsOffsets = new HashMap<>();
-        TopicPartition tp = new TopicPartition(TEST_TOPIC, TEST_PARTITION);
         long offset = ListOffsetsRequest.EARLIEST_TIMESTAMP;
-        partitionsOffsets.put(tp, offset);
+        partitionsOffsets.put(TEST_PARTITION_1, offset);
 
-        expectSuccessfulRequest();
+        expectSuccessfulRequest(Collections.singletonMap(TEST_PARTITION_1, LEADER_1));
         CompletableFuture<Map<TopicPartition, Long>> result = requestManager.fetchOffsets(
                 partitionsOffsets.keySet(),
                 ListOffsetsRequest.EARLIEST_TIMESTAMP,
@@ -91,24 +101,17 @@ public class ListOffsetsRequestManagerTest {
         assertEquals(1, requestManager.requestsToSend());
         assertEquals(0, requestManager.requestsToRetry());
 
-        NetworkClientDelegate.PollResult res = requestManager.poll(time.milliseconds());
-        verifySuccessfulPoll(res);
-
-        NetworkClientDelegate.UnsentRequest unsentRequest = res.unsentRequests.get(0);
-        unsentRequest.future().complete(buildListOffsetsClientResponse(unsentRequest,
-                partitionsOffsets));
-
-        verifyRequestSuccessfullyCompleted(tp, offset, result, partitionsOffsets);
+        verifySuccessfulPollAndResponseReceived(result, partitionsOffsets);
     }
 
     @Test
-    public void testListOffsetsRequest_FailAndRetrySuccess() throws ExecutionException, InterruptedException {
+    public void testBuildingRequestFails_RetrySucceeds() throws ExecutionException,
+            InterruptedException {
         Map<TopicPartition, Long> partitionsOffsets = new HashMap<>();
-        TopicPartition tp = new TopicPartition(TEST_TOPIC, TEST_PARTITION);
         long offset = 1L;
-        partitionsOffsets.put(tp, offset);
+        partitionsOffsets.put(TEST_PARTITION_1, offset);
 
-        // List offsets request that fails with unknown leader
+        // Building list offsets request fails with unknown leader
         expectFailedRequest_MissingLeader();
         CompletableFuture<Map<TopicPartition, Long>> fetchOffsetsFuture =
                 requestManager.fetchOffsets(partitionsOffsets.keySet(),
@@ -120,75 +123,261 @@ public class ListOffsetsRequestManagerTest {
         assertEquals(0, res.unsentRequests.size());
         assertFalse(fetchOffsetsFuture.isDone());
 
-        // Mock metadata update. Previously failed request should be retried and succeed
-        expectSuccessfulRequest();
+        // Cluster metadata update. Previously failed attempt to build the request should be retried
+        // and succeed
+        expectSuccessfulRequest(Collections.singletonMap(TEST_PARTITION_1, LEADER_1));
         requestManager.onUpdate(new ClusterResource(""));
         assertEquals(1, requestManager.requestsToSend());
 
-        // Request manager poll
-        NetworkClientDelegate.PollResult retriedPoll = requestManager.poll(time.milliseconds());
-        verifySuccessfulPoll(retriedPoll);
-
-        // Complete poll result
-        NetworkClientDelegate.UnsentRequest unsentRequest = retriedPoll.unsentRequests.get(0);
-        unsentRequest.future().complete(buildListOffsetsClientResponse(unsentRequest, partitionsOffsets));
-
-        verifyRequestSuccessfullyCompleted(tp, offset, fetchOffsetsFuture, partitionsOffsets);
-
+        verifySuccessfulPollAndResponseReceived(fetchOffsetsFuture, partitionsOffsets);
     }
 
-    private void expectSuccessfulRequest() {
-        when(metadata.currentLeader(any(TopicPartition.class))).thenReturn(testLeaderEpoch());
-        when(metadata.fetch()).thenReturn(testClusterMetadata());
-        when(subscriptionState.isAssigned(any(TopicPartition.class))).thenReturn(true);
+    @ParameterizedTest
+    @MethodSource("retriableErrors")
+    public void testRequestFailsWithRetriableError_RetrySucceeds(Errors error) throws ExecutionException, InterruptedException {
+        Map<TopicPartition, Long> partitionsOffsets = new HashMap<>();
+        long offset = 1L;
+        partitionsOffsets.put(TEST_PARTITION_1, offset);
+
+        // List offsets request that is successfully built
+        expectSuccessfulRequest(Collections.singletonMap(TEST_PARTITION_1, LEADER_1));
+        CompletableFuture<Map<TopicPartition, Long>> fetchOffsetsFuture = requestManager.fetchOffsets(
+                partitionsOffsets.keySet(),
+                ListOffsetsRequest.EARLIEST_TIMESTAMP,
+                false);
+        assertEquals(1, requestManager.requestsToSend());
+        assertEquals(0, requestManager.requestsToRetry());
+
+        // Request successfully sent to single broker
+        NetworkClientDelegate.PollResult res = requestManager.poll(time.milliseconds());
+        verifySuccessfulPoll(res);
+        assertFalse(fetchOffsetsFuture.isDone());
+
+        // Failed response received
+        NetworkClientDelegate.UnsentRequest unsentRequest = res.unsentRequests.get(0);
+        unsentRequest.future().complete(
+                buildClientResponseWithErrors(
+                        unsentRequest,
+                        Collections.singletonMap(TEST_PARTITION_1, error)));
+        assertFalse(fetchOffsetsFuture.isDone());
+        assertEquals(1, requestManager.requestsToRetry());
+        assertEquals(0, requestManager.requestsToSend());
+
+        // Cluster metadata update. Failed requests should be retried
+        expectSuccessfulRequest(Collections.singletonMap(TEST_PARTITION_1, LEADER_1));
+        requestManager.onUpdate(new ClusterResource(""));
+        assertEquals(1, requestManager.requestsToSend());
+
+        verifySuccessfulPollAndResponseReceived(fetchOffsetsFuture, partitionsOffsets);
+    }
+
+    private static Stream<Arguments> retriableErrors() {
+        return Stream.of(
+                Arguments.of(Errors.NOT_LEADER_OR_FOLLOWER),
+                Arguments.of(Errors.REPLICA_NOT_AVAILABLE),
+                Arguments.of(Errors.KAFKA_STORAGE_ERROR),
+                Arguments.of(Errors.OFFSET_NOT_AVAILABLE),
+                Arguments.of(Errors.LEADER_NOT_AVAILABLE),
+                Arguments.of(Errors.FENCED_LEADER_EPOCH),
+                Arguments.of(Errors.UNKNOWN_LEADER_EPOCH));
+    }
+
+    @Test
+    public void testRequestPartiallyFailsWithRetriableError_RetrySucceeds() throws ExecutionException, InterruptedException {
+        Map<TopicPartition, Long> partitionsOffsets = new HashMap<>();
+        long offset = ListOffsetsRequest.EARLIEST_TIMESTAMP;
+        partitionsOffsets.put(TEST_PARTITION_1, offset);
+        partitionsOffsets.put(TEST_PARTITION_2, offset);
+
+        // List offsets request to 2 brokers successfully built
+        Map<TopicPartition, Node> partitionLeaders = new HashMap<>();
+        partitionLeaders.put(TEST_PARTITION_1, LEADER_1);
+        partitionLeaders.put(TEST_PARTITION_2, LEADER_2);
+        expectSuccessfulRequest(partitionLeaders);
+        CompletableFuture<Map<TopicPartition, Long>> fetchOffsetsFuture = requestManager.fetchOffsets(
+                partitionsOffsets.keySet(),
+                ListOffsetsRequest.EARLIEST_TIMESTAMP,
+                false);
+        assertEquals(2, requestManager.requestsToSend());
+        assertEquals(0, requestManager.requestsToRetry());
+
+        // Request successfully sent to both brokers
+        NetworkClientDelegate.PollResult res = requestManager.poll(time.milliseconds());
+        verifySuccessfulPoll(res, 2);
+        assertFalse(fetchOffsetsFuture.isDone());
+
+        // Mixed response with failures and successes. Offsets successfully fetched from one
+        // broker but retriable UNKNOWN_LEADER_EPOCH received from second broker.
+        NetworkClientDelegate.UnsentRequest unsentRequest1 = res.unsentRequests.get(0);
+        unsentRequest1.future().complete(
+                buildClientResponseWithOffsets(
+                        unsentRequest1,
+                        Collections.singletonMap(TEST_PARTITION_1, offset)));
+        NetworkClientDelegate.UnsentRequest unsentRequest2 = res.unsentRequests.get(1);
+        unsentRequest2.future().complete(
+                buildClientResponseWithErrors(
+                        unsentRequest2,
+                        Collections.singletonMap(TEST_PARTITION_2, Errors.UNKNOWN_LEADER_EPOCH)));
+
+        assertFalse(fetchOffsetsFuture.isDone());
+        assertEquals(1, requestManager.requestsToRetry());
+        assertEquals(0, requestManager.requestsToSend());
+
+        // Cluster metadata update. Failed requests should be retried
+        expectSuccessfulRequest(partitionLeaders);
+        requestManager.onUpdate(new ClusterResource(""));
+        assertEquals(1, requestManager.requestsToSend());
+
+        // Following poll should send the request and get a successful response
+        NetworkClientDelegate.PollResult retriedPoll = requestManager.poll(time.milliseconds());
+        verifySuccessfulPoll(retriedPoll);
+        NetworkClientDelegate.UnsentRequest unsentRequest = retriedPoll.unsentRequests.get(0);
+        unsentRequest.future().complete(buildClientResponseWithOffsets(unsentRequest, Collections.singletonMap(TEST_PARTITION_2, offset)));
+
+        // Verify global result with the offset initially retrieved, and the offset that
+        // initially failed but succeeded after a metadata update
+        verifyRequestSuccessfullyCompleted(fetchOffsetsFuture, partitionsOffsets);
+    }
+
+    @Test
+    public void testRequestFailedResponse_NonRetriableAuthError() {
+        Map<TopicPartition, Long> partitionsOffsets = new HashMap<>();
+        long offset = 1L;
+        partitionsOffsets.put(TEST_PARTITION_1, offset);
+
+        // List offsets request that is successfully built
+        expectSuccessfulRequest(Collections.singletonMap(TEST_PARTITION_1, LEADER_1));
+        CompletableFuture<Map<TopicPartition, Long>> fetchOffsetsFuture = requestManager.fetchOffsets(
+                partitionsOffsets.keySet(),
+                ListOffsetsRequest.EARLIEST_TIMESTAMP,
+                false);
+        assertEquals(1, requestManager.requestsToSend());
+        assertEquals(0, requestManager.requestsToRetry());
+
+        // Request successfully sent
+        NetworkClientDelegate.PollResult res = requestManager.poll(time.milliseconds());
+        verifySuccessfulPoll(res);
+
+        // Failed response received
+        NetworkClientDelegate.UnsentRequest unsentRequest = res.unsentRequests.get(0);
+        unsentRequest.future().complete(
+                buildClientResponseWithErrors(
+                        unsentRequest,
+                        Collections.singletonMap(TEST_PARTITION_1, Errors.TOPIC_AUTHORIZATION_FAILED)));
+
+        // Request completed with error. Nothing pending to be sent or retried
+        verifyRequestCompletedWithErrorResponse(fetchOffsetsFuture, TopicAuthorizationException.class);
+        assertEquals(0, requestManager.requestsToRetry());
+        assertEquals(0, requestManager.requestsToSend());
+    }
+
+    private void verifySuccessfulPollAndResponseReceived(CompletableFuture<Map<TopicPartition, Long>> actualResult,
+                                                         Map<TopicPartition, Long> expectedResult) throws ExecutionException, InterruptedException {
+        // Following poll should send the request and get a response
+        NetworkClientDelegate.PollResult retriedPoll = requestManager.poll(time.milliseconds());
+        verifySuccessfulPoll(retriedPoll);
+        NetworkClientDelegate.UnsentRequest unsentRequest = retriedPoll.unsentRequests.get(0);
+        unsentRequest.future().complete(buildClientResponseWithOffsets(unsentRequest, expectedResult));
+        verifyRequestSuccessfullyCompleted(actualResult, expectedResult);
+    }
+
+    private void expectSuccessfulRequest(Map<TopicPartition, Node> partitionLeaders) {
+        partitionLeaders.forEach((tp, broker) -> {
+            when(metadata.currentLeader(tp)).thenReturn(testLeaderEpoch(broker));
+            when(subscriptionState.isAssigned(tp)).thenReturn(true);
+        });
+        when(metadata.fetch()).thenReturn(testClusterMetadata(partitionLeaders));
     }
 
     private void expectFailedRequest_MissingLeader() {
         when(metadata.currentLeader(any(TopicPartition.class))).thenReturn(
                 new Metadata.LeaderAndEpoch(Optional.empty(), Optional.of(1)));
-        when(metadata.fetch()).thenReturn(testClusterMetadata());
         when(subscriptionState.isAssigned(any(TopicPartition.class))).thenReturn(true);
     }
 
     private void verifySuccessfulPoll(NetworkClientDelegate.PollResult pollResult) {
-        assertEquals(0, requestManager.requestsToSend());
-        assertEquals(0, requestManager.requestsToRetry());
-        assertEquals(1, pollResult.unsentRequests.size());
+        verifySuccessfulPoll(pollResult, 1);
     }
 
-    private void verifyRequestSuccessfullyCompleted(TopicPartition tp,
-                                                    long offset,
-                                                    CompletableFuture<Map<TopicPartition, Long>> actualResult,
-                                                    Map<TopicPartition, Long> expectedResult) throws ExecutionException, InterruptedException {
+    private void verifySuccessfulPoll(NetworkClientDelegate.PollResult pollResult,
+                                      int requestCount) {
+        assertEquals(0, requestManager.requestsToSend());
+        assertEquals(0, requestManager.requestsToRetry());
+        assertEquals(requestCount, pollResult.unsentRequests.size());
+    }
+
+    private void verifyRequestSuccessfullyCompleted(CompletableFuture<Map<TopicPartition, Long>> actualResult,
+                                                    Map<TopicPartition, Long> expectedResult)
+            throws ExecutionException, InterruptedException {
         assertEquals(0, requestManager.requestsToRetry());
         assertEquals(0, requestManager.requestsToSend());
 
         assertTrue(actualResult.isDone());
         assertFalse(actualResult.isCompletedExceptionally());
-        assertEquals(expectedResult, actualResult.get());
-
-        verify(subscriptionState).updateLastStableOffset(tp, offset);
+        Map<TopicPartition, Long> partitionOffsets = actualResult.get();
+        assertEquals(expectedResult, partitionOffsets);
+        verifySubscriptionStateUpdated(expectedResult);
     }
 
-    private Metadata.LeaderAndEpoch testLeaderEpoch() {
-        return new Metadata.LeaderAndEpoch(Optional.of(LEADER_1),
+    private void verifySubscriptionStateUpdated(Map<TopicPartition, Long> expectedResult) {
+        ArgumentCaptor<TopicPartition> tpCaptor = ArgumentCaptor.forClass(TopicPartition.class);
+        ArgumentCaptor<Long> offsetCaptor = ArgumentCaptor.forClass(Long.class);
+
+        verify(subscriptionState, times(expectedResult.size())).updateLastStableOffset(tpCaptor.capture(),
+                offsetCaptor.capture());
+
+        List<TopicPartition> updatedTp = tpCaptor.getAllValues();
+        List<Long> updatedOffsets = offsetCaptor.getAllValues();
+        assertEquals(expectedResult.keySet(), new HashSet<>(updatedTp));
+        assertEquals(new ArrayList<>(expectedResult.values()), updatedOffsets);
+    }
+
+    private void verifyRequestCompletedWithErrorResponse(CompletableFuture<Map<TopicPartition, Long>> actualResult,
+                                                         Class<? extends Throwable> expectedFailure) {
+        assertTrue(actualResult.isDone());
+        assertTrue(actualResult.isCompletedExceptionally());
+        Throwable failure = assertThrows(ExecutionException.class, actualResult::get);
+        assertEquals(expectedFailure, failure.getCause().getClass());
+    }
+
+    private Metadata.LeaderAndEpoch testLeaderEpoch(Node leader) {
+        return new Metadata.LeaderAndEpoch(Optional.of(leader),
                 Optional.of(1));
     }
 
-    private Cluster testClusterMetadata() {
-        List<PartitionInfo> partitions = Collections.singletonList(
-                new PartitionInfo(TEST_TOPIC, TEST_PARTITION, LEADER_1, null, null));
-        return new Cluster("clusterId", Collections.singletonList(LEADER_1), partitions, Collections.emptySet(),
+    private Cluster testClusterMetadata(Map<TopicPartition, Node> partitionLeaders) {
+        List<PartitionInfo> partitions =
+                partitionLeaders.keySet().stream()
+                        .map(tp -> new PartitionInfo(tp.topic(), tp.partition(),
+                                partitionLeaders.get(tp), null, null))
+                        .collect(Collectors.toList());
+
+        return new Cluster("clusterId", partitionLeaders.values(), partitions,
+                Collections.emptySet(),
                 Collections.emptySet());
     }
 
-    private ClientResponse buildListOffsetsClientResponse(
+    private ClientResponse buildClientResponseWithOffsets(
             final NetworkClientDelegate.UnsentRequest request,
             final Map<TopicPartition, Long> partitionsOffsets) {
+        return buildClientResponse(request, partitionsOffsets, Collections.emptyMap());
+    }
+
+    private ClientResponse buildClientResponseWithErrors(
+            final NetworkClientDelegate.UnsentRequest request,
+            final Map<TopicPartition, Errors> partitionsErrors) {
+        return buildClientResponse(request, Collections.emptyMap(), partitionsErrors);
+    }
+
+    private ClientResponse buildClientResponse(
+            final NetworkClientDelegate.UnsentRequest request,
+            final Map<TopicPartition, Long> partitionsOffsets,
+            final Map<TopicPartition, Errors> partitionsErrors) {
         AbstractRequest abstractRequest = request.requestBuilder().build();
         assertTrue(abstractRequest instanceof ListOffsetsRequest);
         ListOffsetsRequest offsetFetchRequest = (ListOffsetsRequest) abstractRequest;
-        ListOffsetsResponse response = buildListOffsetsResponse(partitionsOffsets);
+        ListOffsetsResponse response = buildListOffsetsResponse(partitionsOffsets,
+                partitionsErrors);
         return new ClientResponse(
                 new RequestHeader(ApiKeys.OFFSET_FETCH, offsetFetchRequest.version(), "", 1),
                 request.callback(),
@@ -202,11 +391,21 @@ public class ListOffsetsRequestManagerTest {
         );
     }
 
-    private ListOffsetsResponse buildListOffsetsResponse(Map<TopicPartition, Long> offsets) {
+    private ListOffsetsResponse buildListOffsetsResponse(Map<TopicPartition, Long> partitionsOffsets,
+                                                         Map<TopicPartition, Errors> partitionsErrors) {
         List<ListOffsetsResponseData.ListOffsetsTopicResponse> offsetsTopicResponses = new ArrayList<>();
-        offsets.forEach((tp, offset) -> offsetsTopicResponses.add(
+        // Generate successful responses
+        partitionsOffsets.forEach((tp, offset) -> offsetsTopicResponses.add(
                 ListOffsetsResponse.singletonListOffsetsTopicResponse(tp, Errors.NONE, -1L,
                         offset, 123)));
+
+        // Generate responses with error
+        partitionsErrors.forEach((tp, error) -> offsetsTopicResponses.add(
+                ListOffsetsResponse.singletonListOffsetsTopicResponse(
+                        tp, error,
+                        ListOffsetsResponse.UNKNOWN_TIMESTAMP,
+                        ListOffsetsResponse.UNKNOWN_OFFSET,
+                        ListOffsetsResponse.UNKNOWN_EPOCH)));
 
         ListOffsetsResponseData responseData = new ListOffsetsResponseData()
                 .setThrottleTimeMs(0)

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ListOffsetsRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ListOffsetsRequestManagerTest.java
@@ -1,0 +1,217 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer.internals;
+
+import org.apache.kafka.clients.ApiVersions;
+import org.apache.kafka.clients.ClientResponse;
+import org.apache.kafka.clients.Metadata;
+import org.apache.kafka.common.Cluster;
+import org.apache.kafka.common.ClusterResource;
+import org.apache.kafka.common.IsolationLevel;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.message.ListOffsetsResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.AbstractRequest;
+import org.apache.kafka.common.requests.ListOffsetsRequest;
+import org.apache.kafka.common.requests.ListOffsetsResponse;
+import org.apache.kafka.common.requests.RequestHeader;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.common.utils.Time;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class ListOffsetsRequestManagerTest {
+
+    private ListOffsetsRequestManager requestManager;
+    private ConsumerMetadata metadata;
+    private SubscriptionState subscriptionState;
+    private MockTime time;
+    private static final String TEST_TOPIC = "t1";
+    private static final int TEST_PARTITION = 1;
+    private static final Node LEADER_1 = new Node(0, "localhost", 9092);
+    private static final IsolationLevel DEFAULT_ISOLATION_LEVEL = IsolationLevel.READ_COMMITTED;
+
+    @BeforeEach
+    public void setup() {
+        metadata = mock(ConsumerMetadata.class);
+        subscriptionState = mock(SubscriptionState.class);
+        this.time = new MockTime(0);
+        requestManager = new ListOffsetsRequestManager(subscriptionState,
+                metadata, DEFAULT_ISOLATION_LEVEL, mock(Time.class),
+                mock(ApiVersions.class), new LogContext());
+    }
+
+    @Test
+    public void testListOffsetsRequest_Success() throws ExecutionException, InterruptedException {
+        Map<TopicPartition, Long> partitionsOffsets = new HashMap<>();
+        TopicPartition tp = new TopicPartition(TEST_TOPIC, TEST_PARTITION);
+        long offset = ListOffsetsRequest.EARLIEST_TIMESTAMP;
+        partitionsOffsets.put(tp, offset);
+
+        expectSuccessfulRequest();
+        CompletableFuture<Map<TopicPartition, Long>> result = requestManager.fetchOffsets(
+                partitionsOffsets.keySet(),
+                ListOffsetsRequest.EARLIEST_TIMESTAMP,
+                false);
+        assertEquals(1, requestManager.requestsToSend());
+        assertEquals(0, requestManager.requestsToRetry());
+
+        NetworkClientDelegate.PollResult res = requestManager.poll(time.milliseconds());
+        verifySuccessfulPoll(res);
+
+        NetworkClientDelegate.UnsentRequest unsentRequest = res.unsentRequests.get(0);
+        unsentRequest.future().complete(buildListOffsetsClientResponse(unsentRequest,
+                partitionsOffsets));
+
+        verifyRequestSuccessfullyCompleted(tp, offset, result, partitionsOffsets);
+    }
+
+    @Test
+    public void testListOffsetsRequest_FailAndRetrySuccess() throws ExecutionException, InterruptedException {
+        Map<TopicPartition, Long> partitionsOffsets = new HashMap<>();
+        TopicPartition tp = new TopicPartition(TEST_TOPIC, TEST_PARTITION);
+        long offset = 1L;
+        partitionsOffsets.put(tp, offset);
+
+        // List offsets request that fails with unknown leader
+        expectFailedRequest_MissingLeader();
+        CompletableFuture<Map<TopicPartition, Long>> fetchOffsetsFuture =
+                requestManager.fetchOffsets(partitionsOffsets.keySet(),
+                        ListOffsetsRequest.EARLIEST_TIMESTAMP,
+                        false);
+        assertEquals(0, requestManager.requestsToSend());
+        assertEquals(1, requestManager.requestsToRetry());
+        NetworkClientDelegate.PollResult res = requestManager.poll(time.milliseconds());
+        assertEquals(0, res.unsentRequests.size());
+        assertFalse(fetchOffsetsFuture.isDone());
+
+        // Mock metadata update. Previously failed request should be retried and succeed
+        expectSuccessfulRequest();
+        requestManager.onUpdate(new ClusterResource(""));
+        assertEquals(1, requestManager.requestsToSend());
+
+        // Request manager poll
+        NetworkClientDelegate.PollResult retriedPoll = requestManager.poll(time.milliseconds());
+        verifySuccessfulPoll(retriedPoll);
+
+        // Complete poll result
+        NetworkClientDelegate.UnsentRequest unsentRequest = retriedPoll.unsentRequests.get(0);
+        unsentRequest.future().complete(buildListOffsetsClientResponse(unsentRequest, partitionsOffsets));
+
+        verifyRequestSuccessfullyCompleted(tp, offset, fetchOffsetsFuture, partitionsOffsets);
+
+    }
+
+    private void expectSuccessfulRequest() {
+        when(metadata.currentLeader(any(TopicPartition.class))).thenReturn(testLeaderEpoch());
+        when(metadata.fetch()).thenReturn(testClusterMetadata());
+        when(subscriptionState.isAssigned(any(TopicPartition.class))).thenReturn(true);
+    }
+
+    private void expectFailedRequest_MissingLeader() {
+        when(metadata.currentLeader(any(TopicPartition.class))).thenReturn(
+                new Metadata.LeaderAndEpoch(Optional.empty(), Optional.of(1)));
+        when(metadata.fetch()).thenReturn(testClusterMetadata());
+        when(subscriptionState.isAssigned(any(TopicPartition.class))).thenReturn(true);
+    }
+
+    private void verifySuccessfulPoll(NetworkClientDelegate.PollResult pollResult) {
+        assertEquals(0, requestManager.requestsToSend());
+        assertEquals(0, requestManager.requestsToRetry());
+        assertEquals(1, pollResult.unsentRequests.size());
+    }
+
+    private void verifyRequestSuccessfullyCompleted(TopicPartition tp,
+                                                    long offset,
+                                                    CompletableFuture<Map<TopicPartition, Long>> actualResult,
+                                                    Map<TopicPartition, Long> expectedResult) throws ExecutionException, InterruptedException {
+        assertEquals(0, requestManager.requestsToRetry());
+        assertEquals(0, requestManager.requestsToSend());
+
+        assertTrue(actualResult.isDone());
+        assertFalse(actualResult.isCompletedExceptionally());
+        assertEquals(expectedResult, actualResult.get());
+
+        verify(subscriptionState).updateLastStableOffset(tp, offset);
+    }
+
+    private Metadata.LeaderAndEpoch testLeaderEpoch() {
+        return new Metadata.LeaderAndEpoch(Optional.of(LEADER_1),
+                Optional.of(1));
+    }
+
+    private Cluster testClusterMetadata() {
+        List<PartitionInfo> partitions = Collections.singletonList(
+                new PartitionInfo(TEST_TOPIC, TEST_PARTITION, LEADER_1, null, null));
+        return new Cluster("clusterId", Collections.singletonList(LEADER_1), partitions, Collections.emptySet(),
+                Collections.emptySet());
+    }
+
+    private ClientResponse buildListOffsetsClientResponse(
+            final NetworkClientDelegate.UnsentRequest request,
+            final Map<TopicPartition, Long> partitionsOffsets) {
+        AbstractRequest abstractRequest = request.requestBuilder().build();
+        assertTrue(abstractRequest instanceof ListOffsetsRequest);
+        ListOffsetsRequest offsetFetchRequest = (ListOffsetsRequest) abstractRequest;
+        ListOffsetsResponse response = buildListOffsetsResponse(partitionsOffsets);
+        return new ClientResponse(
+                new RequestHeader(ApiKeys.OFFSET_FETCH, offsetFetchRequest.version(), "", 1),
+                request.callback(),
+                "-1",
+                time.milliseconds(),
+                time.milliseconds(),
+                false,
+                null,
+                null,
+                response
+        );
+    }
+
+    private ListOffsetsResponse buildListOffsetsResponse(Map<TopicPartition, Long> offsets) {
+        List<ListOffsetsResponseData.ListOffsetsTopicResponse> offsetsTopicResponses = new ArrayList<>();
+        offsets.forEach((tp, offset) -> offsetsTopicResponses.add(
+                ListOffsetsResponse.singletonListOffsetsTopicResponse(tp, Errors.NONE, -1L,
+                        offset, 123)));
+
+        ListOffsetsResponseData responseData = new ListOffsetsResponseData()
+                .setThrottleTimeMs(0)
+                .setTopics(offsetsTopicResponses);
+
+        return new ListOffsetsResponse(responseData);
+    }
+}


### PR DESCRIPTION
Implementation of ListOffsetRequestManager and beginning and end offsets integrated with it.

Note on metadata interaction:
This includes metadata interaction based only on the ConsumerMetadata object that is maintained up-to-date by the network client. The ListOffsetRequest manager calls the ConsumerMetadata object `requestUpdate` when needed, and gets notified of the updates by implementing the existing ClusterResourceListener.
