### PR TITLE
KAFKA-14274 #2: refactoring application and background events

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/NoopBackgroundEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/NoopBackgroundEvent.java
@@ -22,10 +22,11 @@ import org.apache.kafka.clients.consumer.internals.events.BackgroundEvent;
  * Noop event. Intentionally left it here for demonstration purpose.
  */
 public class NoopBackgroundEvent extends BackgroundEvent {
+
     public final String message;
 
     public NoopBackgroundEvent(final String message) {
-        super(EventType.NOOP);
+        super(Type.NOOP);
         this.message = message;
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumer.java
@@ -317,18 +317,7 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
 
         final OffsetFetchApplicationEvent event = new OffsetFetchApplicationEvent(partitions);
         eventHandler.add(event);
-        try {
-            return event.complete(Duration.ofMillis(100));
-        } catch (InterruptedException e) {
-            throw new InterruptException(e);
-        } catch (TimeoutException e) {
-            throw new org.apache.kafka.common.errors.TimeoutException(e);
-        } catch (ExecutionException e) {
-            // Execution exception is thrown here
-            throw new KafkaException(e);
-        } catch (Exception e) {
-            throw e;
-        }
+        return event.get(time.timer(timeout));
     }
 
     private void maybeThrowInvalidGroupIdException() {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumer.java
@@ -315,9 +315,7 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
             return new HashMap<>();
         }
 
-        final OffsetFetchApplicationEvent event = new OffsetFetchApplicationEvent(partitions);
-        eventHandler.add(event);
-        return event.get(time.timer(timeout));
+        return eventHandler.addAndGet(new OffsetFetchApplicationEvent(partitions), timeout);
     }
 
     private void maybeThrowInvalidGroupIdException() {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEvent.java
@@ -16,26 +16,24 @@
  */
 package org.apache.kafka.clients.consumer.internals.events;
 
+import java.util.Objects;
+
 /**
  * This is the abstract definition of the events created by the KafkaConsumer API
  */
-abstract public class ApplicationEvent {
-    public final Type type;
+public abstract class ApplicationEvent {
+
+    public enum Type {
+        NOOP, COMMIT, POLL, FETCH, FETCH_COMMITTED_OFFSET, METADATA_UPDATE, UNSUBSCRIBE,
+    }
+
+    protected final Type type;
 
     protected ApplicationEvent(Type type) {
-        this.type = type;
+        this.type = Objects.requireNonNull(type);
     }
-    /**
-     * process the application event. Return true upon succesful execution,
-     * false otherwise.
-     * @return true if the event was successfully executed; false otherwise.
-     */
 
-    @Override
-    public String toString() {
-        return type + " ApplicationEvent";
-    }
-    public enum Type {
-        NOOP, COMMIT, POLL, FETCH_COMMITTED_OFFSET, METADATA_UPDATE, UNSUBSCRIBE,
+    public Type type() {
+        return type;
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
@@ -68,7 +68,7 @@ public class ApplicationEventProcessor {
      * @param event a {@link NoopApplicationEvent}
      */
     private boolean process(final NoopApplicationEvent event) {
-        return backgroundEventQueue.add(new NoopBackgroundEvent(event.message));
+        return backgroundEventQueue.add(new NoopBackgroundEvent(event.message()));
     }
 
     private boolean process(final PollApplicationEvent event) {
@@ -77,7 +77,7 @@ public class ApplicationEventProcessor {
         }
 
         CommitRequestManager manager = requestManagers.commitRequestManager.get();
-        manager.updateAutoCommitTimer(event.pollTimeMs);
+        manager.updateAutoCommitTimer(event.pollTimeMs());
         return true;
     }
 
@@ -108,7 +108,7 @@ public class ApplicationEventProcessor {
             return false;
         }
         CommitRequestManager manager = requestManagers.commitRequestManager.get();
-        manager.addOffsetFetchRequest(event.partitions);
+        manager.addOffsetFetchRequest(event.partitions());
         return true;
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
@@ -18,7 +18,6 @@ package org.apache.kafka.clients.consumer.internals.events;
 
 import org.apache.kafka.clients.consumer.internals.CommitRequestManager;
 import org.apache.kafka.clients.consumer.internals.ConsumerMetadata;
-import org.apache.kafka.clients.consumer.internals.NoopBackgroundEvent;
 import org.apache.kafka.clients.consumer.internals.RequestManagers;
 import org.apache.kafka.common.KafkaException;
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/BackgroundEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/BackgroundEvent.java
@@ -16,16 +16,24 @@
  */
 package org.apache.kafka.clients.consumer.internals.events;
 
+import java.util.Objects;
+
 /**
  * This is the abstract definition of the events created by the background thread.
  */
-abstract public class BackgroundEvent {
-    public final EventType type;
+public abstract class BackgroundEvent {
 
-    public BackgroundEvent(EventType type) {
-        this.type = type;
-    }
-    public enum EventType {
+    public enum Type {
         NOOP, ERROR,
+    }
+
+    protected final Type type;
+
+    protected BackgroundEvent(Type type) {
+        this.type = Objects.requireNonNull(type);
+    }
+
+    public Type type() {
+        return type;
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/CommitApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/CommitApplicationEvent.java
@@ -19,46 +19,34 @@ package org.apache.kafka.clients.consumer.internals.events;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 
+import java.util.Collections;
 import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 
-public class CommitApplicationEvent extends ApplicationEvent {
-    final private CompletableFuture<Void> future;
-    final private Map<TopicPartition, OffsetAndMetadata> offsets;
+public class CommitApplicationEvent extends CompletableApplicationEvent<Void> {
+
+    private final Map<TopicPartition, OffsetAndMetadata> offsets;
 
     public CommitApplicationEvent(final Map<TopicPartition, OffsetAndMetadata> offsets) {
         super(Type.COMMIT);
-        this.offsets = offsets;
-        Optional<Exception> exception = isValid(offsets);
-        if (exception.isPresent()) {
-            throw new RuntimeException(exception.get());
-        }
-        this.future = new CompletableFuture<>();
-    }
+        this.offsets = Collections.unmodifiableMap(offsets);
 
-    public CompletableFuture<Void> future() {
-        return future;
+        for (OffsetAndMetadata offsetAndMetadata : offsets.values()) {
+            if (offsetAndMetadata.offset() < 0) {
+                throw new IllegalArgumentException("Invalid offset: " + offsetAndMetadata.offset());
+            }
+        }
     }
 
     public Map<TopicPartition, OffsetAndMetadata> offsets() {
         return offsets;
     }
 
-    private Optional<Exception> isValid(final Map<TopicPartition, OffsetAndMetadata> offsets) {
-        for (Map.Entry<TopicPartition, OffsetAndMetadata> entry : offsets.entrySet()) {
-            TopicPartition topicPartition = entry.getKey();
-            OffsetAndMetadata offsetAndMetadata = entry.getValue();
-            if (offsetAndMetadata.offset() < 0) {
-                return Optional.of(new IllegalArgumentException("Invalid offset: " + offsetAndMetadata.offset()));
-            }
-        }
-        return Optional.empty();
-    }
-
     @Override
     public String toString() {
-        return "CommitApplicationEvent("
-                + "offsets=" + offsets + ")";
+        return "CommitApplicationEvent{" +
+                "offsets=" + offsets +
+                ", future=" + future +
+                ", type=" + type +
+                '}';
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/CompletableApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/CompletableApplicationEvent.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer.internals.events;
+
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.errors.InterruptException;
+import org.apache.kafka.common.errors.TimeoutException;
+import org.apache.kafka.common.utils.Timer;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+public abstract class CompletableApplicationEvent<T> extends ApplicationEvent {
+
+    protected final CompletableFuture<T> future;
+
+    protected CompletableApplicationEvent(Type type) {
+        super(type);
+        this.future = new CompletableFuture<>();
+    }
+
+    public CompletableFuture<T> future() {
+        return future;
+    }
+
+    public T get(Timer timer) {
+        try {
+            return future.get(timer.remainingMs(), TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            Throwable t = e.getCause();
+
+            if (t instanceof KafkaException)
+                throw (KafkaException) t;
+            else
+                throw new KafkaException(t);
+        } catch (InterruptedException e) {
+            throw new InterruptException(e);
+        } catch (java.util.concurrent.TimeoutException e) {
+            throw new TimeoutException(e);
+        }
+    }
+
+}

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ErrorBackgroundEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ErrorBackgroundEvent.java
@@ -17,10 +17,22 @@
 package org.apache.kafka.clients.consumer.internals.events;
 
 public class ErrorBackgroundEvent extends BackgroundEvent {
-    private final Throwable exception;
+    private final Throwable error;
 
-    public ErrorBackgroundEvent(Throwable e) {
-        super(EventType.ERROR);
-        exception = e;
+    public ErrorBackgroundEvent(Throwable error) {
+        super(Type.ERROR);
+        this.error = error;
+    }
+
+    public Throwable error() {
+        return error;
+    }
+
+    @Override
+    public String toString() {
+        return "ErrorBackgroundEvent{" +
+                "error=" + error +
+                ", type=" + type +
+                '}';
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/EventHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/EventHandler.java
@@ -16,8 +16,13 @@
  */
 package org.apache.kafka.clients.consumer.internals.events;
 
+import org.apache.kafka.common.utils.Timer;
+
 import java.io.Closeable;
+import java.time.Duration;
 import java.util.Optional;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 /**
  * This class interfaces with the KafkaConsumer and the background thread. It allows the caller to enqueue events via
@@ -43,4 +48,36 @@ public interface EventHandler extends Closeable {
      * @return          true upon successful add.
      */
     boolean add(ApplicationEvent event);
+
+    /**
+     * Add an {@link CompletableApplicationEvent} to the handler. The method blocks, waiting for the result, and will
+     * return the result value upon successful completion; otherwise throws an error.
+     *
+     * <p/>
+     *
+     * See {@link CompletableApplicationEvent#get(Timer)} and {@link Future#get(long, TimeUnit)} for more details.
+     *
+     * @param event     An {@link CompletableApplicationEvent} created by the polling thread.
+     * @param timeoutMs Value in milliseconds for which to wait for the event to complete
+     * @return          Value that is the result of the event
+     * @param <T>       Type of return value of the event
+     */
+    default <T> T addAndGet(CompletableApplicationEvent<T> event, long timeoutMs) {
+        return addAndGet(event, Duration.ofMillis(timeoutMs));
+    }
+
+    /**
+     * Add an {@link CompletableApplicationEvent} to the handler. The method blocks, waiting for the result, and will
+     * return the result value upon successful completion; otherwise throws an error.
+     *
+     * <p/>
+     *
+     * See {@link CompletableApplicationEvent#get(Timer)} and {@link Future#get(long, TimeUnit)} for more details.
+     *
+     * @param event   An {@link CompletableApplicationEvent} created by the polling thread.
+     * @param timeout Duration in milliseconds for which to wait for the event to complete
+     * @return        Value that is the result of the event
+     * @param <T>     Type of return value of the event
+     */
+    <T> T addAndGet(CompletableApplicationEvent<T> event, Duration timeout);
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/MetadataUpdateApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/MetadataUpdateApplicationEvent.java
@@ -24,4 +24,16 @@ public class MetadataUpdateApplicationEvent extends ApplicationEvent {
         super(Type.METADATA_UPDATE);
         this.timestamp = timestamp;
     }
+
+    public long timestamp() {
+        return timestamp;
+    }
+
+    @Override
+    public String toString() {
+        return "MetadataUpdateApplicationEvent{" +
+                "timestamp=" + timestamp +
+                ", type=" + type +
+                '}';
+    }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/NoopApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/NoopApplicationEvent.java
@@ -16,19 +16,29 @@
  */
 package org.apache.kafka.clients.consumer.internals.events;
 
+import java.util.Objects;
+
 /**
- * The event is NoOp. This is intentionally left here for demonstration purpose.
+ * The event is a no-op, but is intentionally left here for demonstration and test purposes.
  */
 public class NoopApplicationEvent extends ApplicationEvent {
-    public final String message;
+
+    private final String message;
 
     public NoopApplicationEvent(final String message) {
         super(Type.NOOP);
-        this.message = message;
+        this.message = Objects.requireNonNull(message);
+    }
+
+    public String message() {
+        return message;
     }
 
     @Override
     public String toString() {
-        return getClass() + "_" + this.message;
+        return "NoopApplicationEvent{" +
+                "message='" + message + '\'' +
+                ", type=" + type +
+                '}';
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/NoopBackgroundEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/NoopBackgroundEvent.java
@@ -14,24 +14,31 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.kafka.clients.consumer.internals;
+package org.apache.kafka.clients.consumer.internals.events;
 
-import org.apache.kafka.clients.consumer.internals.events.BackgroundEvent;
+import java.util.Objects;
 
 /**
- * Noop event. Intentionally left it here for demonstration purpose.
+ * No-op event. Intentionally left it here for demonstration purpose.
  */
 public class NoopBackgroundEvent extends BackgroundEvent {
 
-    public final String message;
+    private final String message;
 
     public NoopBackgroundEvent(final String message) {
         super(Type.NOOP);
-        this.message = message;
+        this.message = Objects.requireNonNull(message);
+    }
+
+    public String message() {
+        return message;
     }
 
     @Override
     public String toString() {
-        return getClass() + "_" + this.message;
+        return "NoopBackgroundEvent{" +
+                "message='" + message + '\'' +
+                ", type=" + type +
+                '}';
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/OffsetFetchApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/OffsetFetchApplicationEvent.java
@@ -19,25 +19,29 @@ package org.apache.kafka.clients.consumer.internals.events;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 
-import java.time.Duration;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
-public class OffsetFetchApplicationEvent extends ApplicationEvent {
-    final public CompletableFuture<Map<TopicPartition, OffsetAndMetadata>> future;
-    public final Set<TopicPartition> partitions;
+public class OffsetFetchApplicationEvent extends CompletableApplicationEvent<Map<TopicPartition, OffsetAndMetadata>> {
+
+    private final Set<TopicPartition> partitions;
 
     public OffsetFetchApplicationEvent(final Set<TopicPartition> partitions) {
         super(Type.FETCH_COMMITTED_OFFSET);
-        this.partitions = partitions;
-        this.future = new CompletableFuture<>();
+        this.partitions = Collections.unmodifiableSet(partitions);
     }
 
-    public Map<TopicPartition, OffsetAndMetadata> complete(final Duration duration) throws ExecutionException, InterruptedException, TimeoutException {
-        return future.get(duration.toMillis(), TimeUnit.MILLISECONDS);
+    public Set<TopicPartition> partitions() {
+        return partitions;
+    }
+
+    @Override
+    public String toString() {
+        return "OffsetFetchApplicationEvent{" +
+                "partitions=" + partitions +
+                ", future=" + future +
+                ", type=" + type +
+                '}';
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/PollApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/PollApplicationEvent.java
@@ -17,10 +17,23 @@
 package org.apache.kafka.clients.consumer.internals.events;
 
 public class PollApplicationEvent extends ApplicationEvent {
-    public final long pollTimeMs;
 
-    protected PollApplicationEvent(final long currentTimeMs) {
+    private final long pollTimeMs;
+
+    public PollApplicationEvent(final long pollTimeMs) {
         super(Type.POLL);
-        this.pollTimeMs = currentTimeMs;
+        this.pollTimeMs = pollTimeMs;
+    }
+
+    public long pollTimeMs() {
+        return pollTimeMs;
+    }
+
+    @Override
+    public String toString() {
+        return "PollApplicationEvent{" +
+                "pollTimeMs=" + pollTimeMs +
+                ", type=" + type +
+                '}';
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/UnsubscribeApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/UnsubscribeApplicationEvent.java
@@ -21,4 +21,11 @@ public class UnsubscribeApplicationEvent extends ApplicationEvent {
     public UnsubscribeApplicationEvent() {
         super(Type.UNSUBSCRIBE);
     }
+
+    @Override
+    public String toString() {
+        return "UnsubscribeApplicationEvent{" +
+                "type=" + type +
+                '}';
+    }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/DefaultEventHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/DefaultEventHandlerTest.java
@@ -21,6 +21,7 @@ import org.apache.kafka.clients.consumer.internals.events.ApplicationEvent;
 import org.apache.kafka.clients.consumer.internals.events.BackgroundEvent;
 import org.apache.kafka.clients.consumer.internals.events.NoopApplicationEvent;
 import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.utils.MockTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -69,7 +70,7 @@ public class DefaultEventHandlerTest {
         final DefaultBackgroundThread bt = mock(DefaultBackgroundThread.class);
         final BlockingQueue<ApplicationEvent> aq = new LinkedBlockingQueue<>();
         final BlockingQueue<BackgroundEvent> bq = new LinkedBlockingQueue<>();
-        final DefaultEventHandler handler = new DefaultEventHandler(bt, aq, bq);
+        final DefaultEventHandler handler = new DefaultEventHandler(new MockTime(), bt, aq, bq);
         assertTrue(handler.isEmpty());
         assertFalse(handler.poll().isPresent());
         handler.add(new NoopApplicationEvent("test"));

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumerTest.java
@@ -39,6 +39,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
+import org.mockito.MockedConstruction;
 
 import java.time.Duration;
 import java.util.Collections;
@@ -150,15 +151,19 @@ public class PrototypeAsyncConsumerTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void testCommitted() {
         Set<TopicPartition> mockTopicPartitions = mockTopicPartitionOffset().keySet();
-        mockConstruction(OffsetFetchApplicationEvent.class, (mock, ctx) -> {
-            when(mock.complete(any())).thenReturn(new HashMap<>());
-        });
-        consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
-        assertDoesNotThrow(() -> consumer.committed(mockTopicPartitions, Duration.ofMillis(1)));
-        verify(eventHandler).add(ArgumentMatchers.isA(OffsetFetchApplicationEvent.class));
+        MockedConstruction<OffsetFetchApplicationEvent> mockedCtor = null;
+
+        try {
+            mockedCtor = mockConstruction(OffsetFetchApplicationEvent.class, (mock, ctx) -> when(mock.get(any())).thenReturn(new HashMap<>()));
+            consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
+            assertDoesNotThrow(() -> consumer.committed(mockTopicPartitions, Duration.ofMillis(1)));
+            verify(eventHandler).add(ArgumentMatchers.isA(OffsetFetchApplicationEvent.class));
+        } finally {
+            if (mockedCtor != null)
+                mockedCtor.close();
+        }
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumerTest.java
@@ -159,7 +159,7 @@ public class PrototypeAsyncConsumerTest {
             mockedCtor = mockConstruction(OffsetFetchApplicationEvent.class, (mock, ctx) -> when(mock.get(any())).thenReturn(new HashMap<>()));
             consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
             assertDoesNotThrow(() -> consumer.committed(mockTopicPartitions, Duration.ofMillis(1)));
-            verify(eventHandler).add(ArgumentMatchers.isA(OffsetFetchApplicationEvent.class));
+            verify(eventHandler).addAndGet(ArgumentMatchers.isA(OffsetFetchApplicationEvent.class), any(Duration.class));
         } finally {
             if (mockedCtor != null)
                 mockedCtor.close();


### PR DESCRIPTION
Changes:

* Minor clean up of the events classes to make data immutable, private, and implement `toString()`
* Added a new `CompletableApplicationEvent` superclass with a `Future` and some corresponding helper methods to block on the event processing, if desired