### PR TITLE
KAFKA-14274, #3: Introduce IdempotentCloser to ensure resources are only closed once

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/IdempotentCloser.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/IdempotentCloser.java
@@ -67,7 +67,7 @@ import java.util.function.Supplier;
  */
 public class IdempotentCloser implements AutoCloseable {
 
-    private final AtomicBoolean flag;
+    private final AtomicBoolean isClosed;
 
     /**
      * Creates an {@code IdempotentCloser} that is not yet closed.
@@ -79,24 +79,24 @@ public class IdempotentCloser implements AutoCloseable {
     /**
      * Creates an {@code IdempotentCloser} with the given initial state.
      *
-     * @param flag Initial state of closer
+     * @param isClosed Initial value for underlying state
      */
-    public IdempotentCloser(boolean flag) {
-        this.flag = new AtomicBoolean(flag);
+    public IdempotentCloser(boolean isClosed) {
+        this.isClosed = new AtomicBoolean(isClosed);
     }
 
     public void maybeThrowIllegalStateException(Supplier<String> message) {
-        if (flag.get())
+        if (isClosed.get())
             throw new IllegalStateException(message.get());
     }
 
     public void maybeThrowIllegalStateException(String message) {
-        if (flag.get())
+        if (isClosed.get())
             throw new IllegalStateException(message);
     }
 
     public boolean isClosed() {
-        return flag.get();
+        return isClosed.get();
     }
 
     @Override
@@ -109,7 +109,7 @@ public class IdempotentCloser implements AutoCloseable {
     }
 
     public void close(final Runnable onInitialClose, final Runnable onSubsequentClose) {
-        if (flag.compareAndSet(false, true)) {
+        if (isClosed.compareAndSet(false, true)) {
             if (onInitialClose != null)
                 onInitialClose.run();
         } else {
@@ -121,7 +121,7 @@ public class IdempotentCloser implements AutoCloseable {
     @Override
     public String toString() {
         return "IdempotentCloser{" +
-                "flag=" + flag +
+                "isClosed=" + isClosed +
                 '}';
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/IdempotentCloser.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/IdempotentCloser.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer.internals;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * {@code IdempotentCloser} encapsulates some basic logic to ensure that a given resource is only closed once.
+ */
+public class IdempotentCloser implements AutoCloseable {
+
+    private final AtomicBoolean flag = new AtomicBoolean(false);
+
+    public void maybeThrowIllegalStateException(String message) {
+        if (isClosed())
+            throw new IllegalStateException(message);
+    }
+
+    public boolean isClosed() {
+        return flag.get();
+    }
+
+    @Override
+    public void close() {
+        close(null, null);
+    }
+
+    public void close(final Runnable onClose) {
+        close(onClose, null);
+    }
+
+    public void close(final Runnable onClose, final Runnable onPreviousClose) {
+        if (flag.compareAndSet(false, true)) {
+            if (onClose != null)
+                onClose.run();
+        } else {
+            if (onPreviousClose != null)
+                onPreviousClose.run();
+        }
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/IdempotentCloser.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/IdempotentCloser.java
@@ -62,7 +62,8 @@ import java.util.function.Supplier;
  * }
  * </pre>
  *
- * Note that the callbacks are optional
+ * Note that the callbacks are optional and if unused operates as a simple means to ensure resources
+ * are only closed once.
  */
 public class IdempotentCloser implements AutoCloseable {
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/IdempotentCloser.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/IdempotentCloser.java
@@ -85,15 +85,11 @@ public class IdempotentCloser implements AutoCloseable {
     }
 
     public void maybeThrowIllegalStateException(Supplier<String> message) {
-        System.out.println("maybeThrowIllegalStateException - flag: " + flag + ", message: " + message.get());
-
         if (flag.get())
             throw new IllegalStateException(message.get());
     }
 
     public void maybeThrowIllegalStateException(String message) {
-        System.out.println("maybeThrowIllegalStateException - flag: " + flag + ", message: " + message);
-
         if (flag.get())
             throw new IllegalStateException(message);
     }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/IdempotentCloserTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/IdempotentCloserTest.java
@@ -169,30 +169,7 @@ public class IdempotentCloserTest {
         assertTrue(ic.isClosed());
     }
 
-    /**
-     * Tests that the {@link IdempotentCloser} implementation of {@link AutoCloseable#close()} works as expected.
-     */
-    @Test
-    public void testAutoCloseable() {
-        AtomicInteger onCloseCounter = new AtomicInteger();
-
-        try (IdempotentCloser ic = new IdempotentCloser() {
-            /**
-             * This provides us with the ability to track that the default {@link AutoCloseable#close()} method
-             * is called when the variable goes out of scope of the try-with-resources block.
-             */
-            @Override
-            public void close() {
-                close(onCloseCounter::getAndIncrement);
-            }
-        }) {
-            assertFalse(ic.isClosed());
-        }
-
-        assertEquals(1, onCloseCounter.get());
-    }
-
-    /**
+     /**
      * Tests that if the {@link IdempotentCloser} is created with its initial state as closed, the various APIs
      * will behave as expected.
      */

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/IdempotentCloserTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/IdempotentCloserTest.java
@@ -178,7 +178,7 @@ public class IdempotentCloserTest {
 
         try (IdempotentCloser ic = new IdempotentCloser() {
             /**
-             * This provides us with the ability to track that the default {@link AutoCloseable#close()} methods
+             * This provides us with the ability to track that the default {@link AutoCloseable#close()} method
              * is called when the variable goes out of scope of the try-with-resources block.
              */
             @Override

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/IdempotentCloserTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/IdempotentCloserTest.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer.internals;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class IdempotentCloserTest {
+
+    private static final Runnable CALLBACK_NO_OP = () -> {};
+
+    private static final Runnable CALLBACK_WITH_RUNTIME_EXCEPTION = () -> {
+        throw new RuntimeException("Simulated error during callback");
+    };
+
+    /**
+     * Tests basic functionality, i.e. that close <em>means</em> closed.
+     */
+    @Test
+    public void testBasicClose() {
+        IdempotentCloser ic = new IdempotentCloser();
+        assertFalse(ic.isClosed());
+        ic.close();
+        assertTrue(ic.isClosed());
+    }
+
+    /**
+     * Tests that the onClose callback is only invoked once.
+     */
+    @Test
+    public void testCountCloses() {
+        AtomicInteger onCloseCounter = new AtomicInteger();
+        IdempotentCloser ic = new IdempotentCloser();
+
+        // Verify initial invariants.
+        assertFalse(ic.isClosed());
+        assertEquals(0, onCloseCounter.get());
+
+        // Close with our onClose callback to increment our counter.
+        ic.close(onCloseCounter::getAndIncrement);
+        assertTrue(ic.isClosed());
+        assertEquals(1, onCloseCounter.get());
+
+        // Close with our onClose callback again, but verify it wasn't invoked as it was previously closed.
+        ic.close(onCloseCounter::getAndIncrement);
+        assertTrue(ic.isClosed());
+        assertEquals(1, onCloseCounter.get());
+    }
+
+    /**
+     * Tests that the onClose callback is only invoked once, while the onPreviousClose callback can be invoked
+     * a variable number of times.
+     */
+    @Test
+    public void testEnsureIdempotentClose() {
+        AtomicInteger onCloseCounter = new AtomicInteger();
+        AtomicInteger onPreviousCloseCounter = new AtomicInteger();
+
+        IdempotentCloser ic = new IdempotentCloser();
+
+        // Verify initial invariants.
+        assertFalse(ic.isClosed());
+        assertEquals(0, onCloseCounter.get());
+        assertEquals(0, onPreviousCloseCounter.get());
+
+        // Our first close passes in both callbacks. As a result, our onClose callback should be run but our
+        // onPreviousClose callback should not be invoked.
+        ic.close(onCloseCounter::getAndIncrement, onPreviousCloseCounter::getAndIncrement);
+        assertTrue(ic.isClosed());
+        assertEquals(1, onCloseCounter.get());
+        assertEquals(0, onPreviousCloseCounter.get());
+
+        // Our second close again passes in both callbacks. As this is the second close, our onClose callback
+        // should not be run but our onPreviousClose callback should be executed.
+        ic.close(onCloseCounter::getAndIncrement, onPreviousCloseCounter::getAndIncrement);
+        assertTrue(ic.isClosed());
+        assertEquals(1, onCloseCounter.get());
+        assertEquals(1, onPreviousCloseCounter.get());
+
+        // Our third close yet again passes in both callbacks. As before, our onClose callback should not be run
+        // but our onPreviousClose callback should be run again.
+        ic.close(onCloseCounter::getAndIncrement, onPreviousCloseCounter::getAndIncrement);
+        assertTrue(ic.isClosed());
+        assertEquals(1, onCloseCounter.get());
+        assertEquals(2, onPreviousCloseCounter.get());
+    }
+
+    /**
+     * Tests that the {@link IdempotentCloser#maybeThrowIllegalStateException(String)} method will not throw an
+     * exception if the closer is in the "open" state, but if invoked after it's in the "closed" state, it will
+     * throw the exception.
+     */
+    @Test
+    public void testCloseBeforeThrows() {
+        IdempotentCloser ic = new IdempotentCloser();
+
+        // Verify initial invariants.
+        assertFalse(ic.isClosed());
+
+        // maybeThrowIllegalStateException doesn't throw anything since the closer is still in its "open" state.
+        assertDoesNotThrow(() -> ic.maybeThrowIllegalStateException(() -> "test"));
+
+        // Post-close, our call to maybeThrowIllegalStateException will, in fact, throw said exception.
+        ic.close();
+        assertTrue(ic.isClosed());
+        assertThrows(IllegalStateException.class, () -> ic.maybeThrowIllegalStateException(() -> "test"));
+    }
+
+    /**
+     * Tests that if the onClose callback is
+     */
+    @Test
+    public void testErrorsInOnCloseCallbacksAreNotSwallowed() {
+        IdempotentCloser ic = new IdempotentCloser();
+        assertFalse(ic.isClosed());
+        assertThrows(RuntimeException.class, () -> ic.close(CALLBACK_WITH_RUNTIME_EXCEPTION));
+
+        // Make sure we're still closed, though...
+        assertTrue(ic.isClosed());
+    }
+
+    @Test
+    public void testErrorsInOnPreviousCloseCallbacksAreNotSwallowed() {
+        IdempotentCloser ic = new IdempotentCloser();
+        assertFalse(ic.isClosed());
+        ic.close(CALLBACK_NO_OP);
+        assertThrows(RuntimeException.class, () -> ic.close(CALLBACK_NO_OP, CALLBACK_WITH_RUNTIME_EXCEPTION));
+        assertTrue(ic.isClosed());
+    }
+
+    @Test
+    public void testAutoCloseable() {
+        try (IdempotentCloser ic = new IdempotentCloser()) {
+            assertFalse(ic.isClosed());
+        }
+    }
+
+    @Test
+    public void testCreatedClosed() {
+        IdempotentCloser ic = new IdempotentCloser(true);
+        assertTrue(ic.isClosed());
+        assertThrows(IllegalStateException.class, () -> ic.maybeThrowIllegalStateException(() -> "test"));
+        assertDoesNotThrow(() -> ic.close(CALLBACK_WITH_RUNTIME_EXCEPTION));
+    }
+}


### PR DESCRIPTION
This commit adds a little class named `IdempotentCloser` which prevents a resource from being closed more than once.

It will be used in a handful of places in the fetch request manager logic. It's general enough that it could be used elsewhere in the project, but I'm limiting scope to the consumer internals for now.