### PR TITLE
KAFKA-14274, #4: introducing FetchBuffer and FetchCollector

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -85,7 +85,7 @@
               files="(Utils|Topic|KafkaLZ4BlockOutputStream|AclData|JoinGroupRequest).java"/>
 
     <suppress checks="CyclomaticComplexity"
-              files="(AbstractFetch|ConsumerCoordinator|OffsetFetcherUtils|KafkaProducer|ConfigDef|KerberosLogin|AbstractRequest|AbstractResponse|Selector|SslFactory|SslTransportLayer|SaslClientAuthenticator|SaslClientCallbackHandler|SaslServerAuthenticator|AbstractCoordinator|TransactionManager|AbstractStickyAssignor|DefaultSslEngineFactory|Authorizer|RecordAccumulator|MemoryRecords|FetchSessionHandler).java"/>
+              files="(AbstractFetch|ConsumerCoordinator|FetchCollector|OffsetFetcherUtils|KafkaProducer|ConfigDef|KerberosLogin|AbstractRequest|AbstractResponse|Selector|SslFactory|SslTransportLayer|SaslClientAuthenticator|SaslClientCallbackHandler|SaslServerAuthenticator|AbstractCoordinator|TransactionManager|AbstractStickyAssignor|DefaultSslEngineFactory|Authorizer|RecordAccumulator|MemoryRecords|FetchSessionHandler).java"/>
 
     <suppress checks="JavaNCSS"
               files="(AbstractRequest|AbstractResponse|KerberosLogin|WorkerSinkTaskTest|TransactionManagerTest|SenderTest|KafkaAdminClient|ConsumerCoordinatorTest|KafkaAdminClientTest|KafkaRaftClientTest).java"/>

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -909,7 +909,16 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                 }
 
                 throwIfNoAssignorsConfigured();
-                fetcher.clearBufferedDataForUnassignedTopics(topics);
+
+                // Clear the buffered data which are not a part of newly assigned topics
+                final Set<TopicPartition> currentTopicPartitions = new HashSet<>();
+
+                for (TopicPartition tp : subscriptions.assignedPartitions()) {
+                    if (topics.contains(tp.topic()))
+                        currentTopicPartitions.add(tp);
+                }
+
+                fetcher.clearBufferedDataForUnassignedPartitions(currentTopicPartitions);
                 log.info("Subscribed to topic(s): {}", join(topics, ", "));
                 if (this.subscriptions.subscribe(new HashSet<>(topics), listener))
                     metadata.requestUpdateForNewTopics();

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractFetch.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractFetch.java
@@ -88,6 +88,18 @@ public abstract class AbstractFetch<K, V> implements Closeable {
         this.time = time;
     }
 
+    boolean hasCompletedFetches() {
+        return !fetchBuffer.isEmpty();
+    }
+
+    /**
+     * Return whether we have any completed fetches that are fetchable. This method is thread-safe.
+     * @return true if there are completed fetches that can be returned, false otherwise
+     */
+    public boolean hasAvailableFetches() {
+        return fetchBuffer.hasCompletedFetches(fetch -> subscriptions.isFetchable(fetch.partition));
+    }
+
     /**
      * Implements the core logic for a successful fetch request/response.
      *

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractFetch.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractFetch.java
@@ -88,6 +88,12 @@ public abstract class AbstractFetch<K, V> implements Closeable {
         this.time = time;
     }
 
+    /**
+     * Return whether we have any completed fetches pending return to the user. This method is thread-safe. Has
+     * visibility for testing.
+     *
+     * @return true if there are completed fetches, false otherwise
+     */
     boolean hasCompletedFetches() {
         return !fetchBuffer.isEmpty();
     }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractFetch.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractFetch.java
@@ -18,45 +18,30 @@ package org.apache.kafka.clients.consumer.internals;
 
 import org.apache.kafka.clients.ClientResponse;
 import org.apache.kafka.clients.FetchSessionHandler;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.clients.consumer.OffsetOutOfRangeException;
 import org.apache.kafka.common.Cluster;
-import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
-import org.apache.kafka.common.errors.RecordTooLargeException;
-import org.apache.kafka.common.errors.TopicAuthorizationException;
 import org.apache.kafka.common.message.FetchResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
-import org.apache.kafka.common.record.RecordBatch;
 import org.apache.kafka.common.requests.FetchRequest;
 import org.apache.kafka.common.requests.FetchResponse;
 import org.apache.kafka.common.utils.BufferSupplier;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Timer;
-import org.apache.kafka.common.utils.Utils;
 import org.slf4j.Logger;
 import org.slf4j.helpers.MessageFormatter;
 
 import java.io.Closeable;
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Queue;
 import java.util.Set;
-import java.util.concurrent.ConcurrentLinkedQueue;
 
 import static org.apache.kafka.clients.consumer.internals.FetchUtils.requestMetadataUpdate;
 
@@ -75,13 +60,12 @@ public abstract class AbstractFetch<K, V> implements Closeable {
     protected final FetchConfig<K, V> fetchConfig;
     protected final Time time;
     protected final FetchMetricsManager metricsManager;
+    protected final FetchBuffer<K, V> fetchBuffer;
+    protected final BufferSupplier decompressionBufferSupplier;
+    protected final Set<Integer> nodesWithPendingFetchRequests;
+    protected final IdempotentCloser idempotentCloser = new IdempotentCloser();
 
-    private final BufferSupplier decompressionBufferSupplier;
-    private final ConcurrentLinkedQueue<CompletedFetch<K, V>> completedFetches;
     private final Map<Integer, FetchSessionHandler> sessionHandlers;
-    private final Set<Integer> nodesWithPendingFetchRequests;
-
-    private CompletedFetch<K, V> nextInLineFetch;
 
     public AbstractFetch(final LogContext logContext,
                          final ConsumerNetworkClient client,
@@ -97,29 +81,11 @@ public abstract class AbstractFetch<K, V> implements Closeable {
         this.subscriptions = subscriptions;
         this.fetchConfig = fetchConfig;
         this.decompressionBufferSupplier = BufferSupplier.create();
-        this.completedFetches = new ConcurrentLinkedQueue<>();
+        this.fetchBuffer = new FetchBuffer<>(logContext);
         this.sessionHandlers = new HashMap<>();
         this.nodesWithPendingFetchRequests = new HashSet<>();
         this.metricsManager = metricsManager;
         this.time = time;
-    }
-
-    /**
-     * Return whether we have any completed fetches pending return to the user. This method is thread-safe. Has
-     * visibility for testing.
-     *
-     * @return true if there are completed fetches, false otherwise
-     */
-    boolean hasCompletedFetches() {
-        return !completedFetches.isEmpty();
-    }
-
-    /**
-     * Return whether we have any completed fetches that are fetchable. This method is thread-safe.
-     * @return true if there are completed fetches that can be returned, false otherwise
-     */
-    public boolean hasAvailableFetches() {
-        return completedFetches.stream().anyMatch(fetch -> subscriptions.isFetchable(fetch.partition));
     }
 
     /**
@@ -193,7 +159,7 @@ public abstract class AbstractFetch<K, V> implements Closeable {
                         metricAggregator,
                         fetchOffset,
                         requestVersion);
-                completedFetches.add(completedFetch);
+                fetchBuffer.add(completedFetch);
             }
 
             metricsManager.recordLatency(resp.requestLatencyMs());
@@ -207,20 +173,34 @@ public abstract class AbstractFetch<K, V> implements Closeable {
      * Implements the core logic for a failed fetch request/response.
      *
      * @param fetchTarget {@link Node} from which the fetch data was requested
-     * @param e {@link RuntimeException} representing the error that resulted in the failure
+     * @param t {@link RuntimeException} representing the error that resulted in the failure
      */
-    protected void handleFetchResponse(final Node fetchTarget, final RuntimeException e) {
+    protected void handleFetchResponse(final Node fetchTarget, final Throwable t) {
         try {
             final FetchSessionHandler handler = sessionHandler(fetchTarget.id());
 
             if (handler != null) {
-                handler.handleError(e);
+                handler.handleError(t);
                 handler.sessionTopicPartitions().forEach(subscriptions::clearPreferredReadReplica);
             }
         } finally {
             log.debug("Removing pending request for node {}", fetchTarget);
             nodesWithPendingFetchRequests.remove(fetchTarget.id());
         }
+    }
+
+    protected void handleCloseFetchSessionResponse(final Node fetchTarget,
+                                                   final FetchSessionHandler.FetchRequestData data) {
+        int sessionId = data.metadata().sessionId();
+        log.debug("Successfully sent a close message for fetch session: {} to node: {}", sessionId, fetchTarget);
+    }
+
+    public void handleCloseFetchSessionResponse(final Node fetchTarget,
+                                                final FetchSessionHandler.FetchRequestData data,
+                                                final Throwable t) {
+        int sessionId = data.metadata().sessionId();
+        log.debug("Unable to a close message for fetch session: {} to node: {}. " +
+                "This may result in unnecessary fetch sessions at the broker.", sessionId, fetchTarget, t);
     }
 
     /**
@@ -257,138 +237,8 @@ public abstract class AbstractFetch<K, V> implements Closeable {
         return request;
     }
 
-    /**
-     * Return the fetched records, empty the record buffer and update the consumed position.
-     *
-     * </p>
-     *
-     * NOTE: returning an {@link Fetch#isEmpty empty} fetch guarantees the consumed position is not updated.
-     *
-     * @return A {@link Fetch} for the requested partitions
-     * @throws OffsetOutOfRangeException If there is OffsetOutOfRange error in fetchResponse and
-     *         the defaultResetPolicy is NONE
-     * @throws TopicAuthorizationException If there is TopicAuthorization error in fetchResponse.
-     */
-    public Fetch<K, V> collectFetch() {
-        Fetch<K, V> fetch = Fetch.empty();
-        Queue<CompletedFetch<K, V>> pausedCompletedFetches = new ArrayDeque<>();
-        int recordsRemaining = fetchConfig.maxPollRecords;
-
-        try {
-            while (recordsRemaining > 0) {
-                if (nextInLineFetch == null || nextInLineFetch.isConsumed()) {
-                    CompletedFetch<K, V> records = completedFetches.peek();
-                    if (records == null) break;
-
-                    if (!records.isInitialized()) {
-                        try {
-                            nextInLineFetch = initializeCompletedFetch(records);
-                        } catch (Exception e) {
-                            // Remove a completedFetch upon a parse with exception if (1) it contains no records, and
-                            // (2) there are no fetched records with actual content preceding this exception.
-                            // The first condition ensures that the completedFetches is not stuck with the same completedFetch
-                            // in cases such as the TopicAuthorizationException, and the second condition ensures that no
-                            // potential data loss due to an exception in a following record.
-                            if (fetch.isEmpty() && FetchResponse.recordsOrFail(records.partitionData).sizeInBytes() == 0) {
-                                completedFetches.poll();
-                            }
-                            throw e;
-                        }
-                    } else {
-                        nextInLineFetch = records;
-                    }
-                    completedFetches.poll();
-                } else if (subscriptions.isPaused(nextInLineFetch.partition)) {
-                    // when the partition is paused we add the records back to the completedFetches queue instead of draining
-                    // them so that they can be returned on a subsequent poll if the partition is resumed at that time
-                    log.debug("Skipping fetching records for assigned partition {} because it is paused", nextInLineFetch.partition);
-                    pausedCompletedFetches.add(nextInLineFetch);
-                    nextInLineFetch = null;
-                } else {
-                    Fetch<K, V> nextFetch = fetchRecords(recordsRemaining);
-                    recordsRemaining -= nextFetch.numRecords();
-                    fetch.add(nextFetch);
-                }
-            }
-        } catch (KafkaException e) {
-            if (fetch.isEmpty())
-                throw e;
-        } finally {
-            // add any polled completed fetches for paused partitions back to the completed fetches queue to be
-            // re-evaluated in the next poll
-            completedFetches.addAll(pausedCompletedFetches);
-        }
-
-        return fetch;
-    }
-
-    private Fetch<K, V> fetchRecords(final int maxRecords) {
-        if (!subscriptions.isAssigned(nextInLineFetch.partition)) {
-            // this can happen when a rebalance happened before fetched records are returned to the consumer's poll call
-            log.debug("Not returning fetched records for partition {} since it is no longer assigned",
-                    nextInLineFetch.partition);
-        } else if (!subscriptions.isFetchable(nextInLineFetch.partition)) {
-            // this can happen when a partition is paused before fetched records are returned to the consumer's
-            // poll call or if the offset is being reset
-            log.debug("Not returning fetched records for assigned partition {} since it is no longer fetchable",
-                    nextInLineFetch.partition);
-        } else {
-            SubscriptionState.FetchPosition position = subscriptions.position(nextInLineFetch.partition);
-            if (position == null) {
-                throw new IllegalStateException("Missing position for fetchable partition " + nextInLineFetch.partition);
-            }
-
-            if (nextInLineFetch.nextFetchOffset() == position.offset) {
-                List<ConsumerRecord<K, V>> partRecords = nextInLineFetch.fetchRecords(maxRecords);
-
-                log.trace("Returning {} fetched records at offset {} for assigned partition {}",
-                        partRecords.size(), position, nextInLineFetch.partition);
-
-                boolean positionAdvanced = false;
-
-                if (nextInLineFetch.nextFetchOffset() > position.offset) {
-                    SubscriptionState.FetchPosition nextPosition = new SubscriptionState.FetchPosition(
-                            nextInLineFetch.nextFetchOffset(),
-                            nextInLineFetch.lastEpoch(),
-                            position.currentLeader);
-                    log.trace("Updating fetch position from {} to {} for partition {} and returning {} records from `poll()`",
-                            position, nextPosition, nextInLineFetch.partition, partRecords.size());
-                    subscriptions.position(nextInLineFetch.partition, nextPosition);
-                    positionAdvanced = true;
-                }
-
-                Long partitionLag = subscriptions.partitionLag(nextInLineFetch.partition, fetchConfig.isolationLevel);
-                if (partitionLag != null)
-                    metricsManager.recordPartitionLag(nextInLineFetch.partition, partitionLag);
-
-                Long lead = subscriptions.partitionLead(nextInLineFetch.partition);
-                if (lead != null) {
-                    metricsManager.recordPartitionLead(nextInLineFetch.partition, lead);
-                }
-
-                return Fetch.forPartition(nextInLineFetch.partition, partRecords, positionAdvanced);
-            } else {
-                // these records aren't next in line based on the last consumed position, ignore them
-                // they must be from an obsolete request
-                log.debug("Ignoring fetched records for {} at offset {} since the current position is {}",
-                        nextInLineFetch.partition, nextInLineFetch.nextFetchOffset(), position);
-            }
-        }
-
-        log.trace("Draining fetched records for partition {}", nextInLineFetch.partition);
-        nextInLineFetch.drain();
-
-        return Fetch.empty();
-    }
-
     private List<TopicPartition> fetchablePartitions() {
-        Set<TopicPartition> exclude = new HashSet<>();
-        if (nextInLineFetch != null && !nextInLineFetch.isConsumed()) {
-            exclude.add(nextInLineFetch.partition);
-        }
-        for (CompletedFetch<K, V> completedFetch : completedFetches) {
-            exclude.add(completedFetch.partition);
-        }
+        Set<TopicPartition> exclude = fetchBuffer.partitions();
         return subscriptions.fetchablePartitions(tp -> !exclude.contains(tp));
     }
 
@@ -429,6 +279,37 @@ public abstract class AbstractFetch<K, V> implements Closeable {
         } else {
             return leaderReplica;
         }
+    }
+
+    protected Map<Node, FetchSessionHandler.FetchRequestData> prepareCloseFetchSessionRequests() {
+        final Cluster cluster = metadata.fetch();
+        Map<Node, FetchSessionHandler.Builder> fetchable = new LinkedHashMap<>();
+
+        try {
+            sessionHandlers.forEach((fetchTargetNodeId, sessionHandler) -> {
+                // set the session handler to notify close. This will set the next metadata request to send close message.
+                sessionHandler.notifyClose();
+
+                // FetchTargetNode may not be available as it may have disconnected the connection. In such cases, we will
+                // skip sending the close request.
+                final Node fetchTarget = cluster.nodeById(fetchTargetNodeId);
+
+                if (fetchTarget == null || client.isUnavailable(fetchTarget)) {
+                    log.debug("Skip sending close session request to broker {} since it is not reachable", fetchTarget);
+                    return;
+                }
+
+                fetchable.put(fetchTarget, sessionHandler.newBuilder());
+            });
+        } finally {
+            sessionHandlers.clear();
+        }
+
+        Map<Node, FetchSessionHandler.FetchRequestData> reqs = new LinkedHashMap<>();
+        for (Map.Entry<Node, FetchSessionHandler.Builder> entry : fetchable.entrySet()) {
+            reqs.put(entry.getKey(), entry.getValue().build());
+        }
+        return reqs;
     }
 
     /**
@@ -495,290 +376,21 @@ public abstract class AbstractFetch<K, V> implements Closeable {
         return reqs;
     }
 
-    /**
-     * Initialize a CompletedFetch object.
-     */
-    private CompletedFetch<K, V> initializeCompletedFetch(final CompletedFetch<K, V> completedFetch) {
-        final TopicPartition tp = completedFetch.partition;
-        final Errors error = Errors.forCode(completedFetch.partitionData.errorCode());
-        boolean recordMetrics = true;
-
-        try {
-            if (!subscriptions.hasValidPosition(tp)) {
-                // this can happen when a rebalance happened while fetch is still in-flight
-                log.debug("Ignoring fetched records for partition {} since it no longer has valid position", tp);
-                return null;
-            } else if (error == Errors.NONE) {
-                final CompletedFetch<K, V> ret = handleInitializeCompletedFetchSuccess(completedFetch);
-                recordMetrics = ret == null;
-                return ret;
-            } else {
-                handleInitializeCompletedFetchErrors(completedFetch, error);
-                return null;
-            }
-        } finally {
-            if (recordMetrics) {
-                completedFetch.recordAggregatedMetrics(0, 0);
-            }
-
-            if (error != Errors.NONE)
-                // we move the partition to the end if there was an error. This way, it's more likely that partitions for
-                // the same topic can remain together (allowing for more efficient serialization).
-                subscriptions.movePartitionToEnd(tp);
-        }
-    }
-
-    private CompletedFetch<K, V> handleInitializeCompletedFetchSuccess(final CompletedFetch<K, V> completedFetch) {
-        final TopicPartition tp = completedFetch.partition;
-        final long fetchOffset = completedFetch.nextFetchOffset();
-
-        // we are interested in this fetch only if the beginning offset matches the
-        // current consumed position
-        SubscriptionState.FetchPosition position = subscriptions.position(tp);
-        if (position == null || position.offset != fetchOffset) {
-            log.debug("Discarding stale fetch response for partition {} since its offset {} does not match " +
-                    "the expected offset {}", tp, fetchOffset, position);
-            return null;
-        }
-
-        final FetchResponseData.PartitionData partition = completedFetch.partitionData;
-        log.trace("Preparing to read {} bytes of data for partition {} with offset {}",
-                FetchResponse.recordsSize(partition), tp, position);
-        Iterator<? extends RecordBatch> batches = FetchResponse.recordsOrFail(partition).batches().iterator();
-
-        if (!batches.hasNext() && FetchResponse.recordsSize(partition) > 0) {
-            if (completedFetch.requestVersion < 3) {
-                // Implement the pre KIP-74 behavior of throwing a RecordTooLargeException.
-                Map<TopicPartition, Long> recordTooLargePartitions = Collections.singletonMap(tp, fetchOffset);
-                throw new RecordTooLargeException("There are some messages at [Partition=Offset]: " +
-                        recordTooLargePartitions + " whose size is larger than the fetch size " + fetchConfig.fetchSize +
-                        " and hence cannot be returned. Please considering upgrading your broker to 0.10.1.0 or " +
-                        "newer to avoid this issue. Alternately, increase the fetch size on the client (using " +
-                        ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG + ")",
-                        recordTooLargePartitions);
-            } else {
-                // This should not happen with brokers that support FetchRequest/Response V3 or higher (i.e. KIP-74)
-                throw new KafkaException("Failed to make progress reading messages at " + tp + "=" +
-                        fetchOffset + ". Received a non-empty fetch response from the server, but no " +
-                        "complete records were found.");
-            }
-        }
-
-        if (partition.highWatermark() >= 0) {
-            log.trace("Updating high watermark for partition {} to {}", tp, partition.highWatermark());
-            subscriptions.updateHighWatermark(tp, partition.highWatermark());
-        }
-
-        if (partition.logStartOffset() >= 0) {
-            log.trace("Updating log start offset for partition {} to {}", tp, partition.logStartOffset());
-            subscriptions.updateLogStartOffset(tp, partition.logStartOffset());
-        }
-
-        if (partition.lastStableOffset() >= 0) {
-            log.trace("Updating last stable offset for partition {} to {}", tp, partition.lastStableOffset());
-            subscriptions.updateLastStableOffset(tp, partition.lastStableOffset());
-        }
-
-        if (FetchResponse.isPreferredReplica(partition)) {
-            subscriptions.updatePreferredReadReplica(completedFetch.partition, partition.preferredReadReplica(), () -> {
-                long expireTimeMs = time.milliseconds() + metadata.metadataExpireMs();
-                log.debug("Updating preferred read replica for partition {} to {}, set to expire at {}",
-                        tp, partition.preferredReadReplica(), expireTimeMs);
-                return expireTimeMs;
-            });
-        }
-
-        completedFetch.setInitialized();
-        return completedFetch;
-    }
-
-    private void handleInitializeCompletedFetchErrors(final CompletedFetch<K, V> completedFetch,
-                                                      final Errors error) {
-        final TopicPartition tp = completedFetch.partition;
-        final long fetchOffset = completedFetch.nextFetchOffset();
-
-        if (error == Errors.NOT_LEADER_OR_FOLLOWER ||
-                error == Errors.REPLICA_NOT_AVAILABLE ||
-                error == Errors.KAFKA_STORAGE_ERROR ||
-                error == Errors.FENCED_LEADER_EPOCH ||
-                error == Errors.OFFSET_NOT_AVAILABLE) {
-            log.debug("Error in fetch for partition {}: {}", tp, error.exceptionName());
-            requestMetadataUpdate(metadata, subscriptions, tp);
-        } else if (error == Errors.UNKNOWN_TOPIC_OR_PARTITION) {
-            log.warn("Received unknown topic or partition error in fetch for partition {}", tp);
-            requestMetadataUpdate(metadata, subscriptions, tp);
-        } else if (error == Errors.UNKNOWN_TOPIC_ID) {
-            log.warn("Received unknown topic ID error in fetch for partition {}", tp);
-            requestMetadataUpdate(metadata, subscriptions, tp);
-        } else if (error == Errors.INCONSISTENT_TOPIC_ID) {
-            log.warn("Received inconsistent topic ID error in fetch for partition {}", tp);
-            requestMetadataUpdate(metadata, subscriptions, tp);
-        } else if (error == Errors.OFFSET_OUT_OF_RANGE) {
-            Optional<Integer> clearedReplicaId = subscriptions.clearPreferredReadReplica(tp);
-
-            if (!clearedReplicaId.isPresent()) {
-                // If there's no preferred replica to clear, we're fetching from the leader so handle this error normally
-                SubscriptionState.FetchPosition position = subscriptions.position(tp);
-
-                if (position == null || fetchOffset != position.offset) {
-                    log.debug("Discarding stale fetch response for partition {} since the fetched offset {} " +
-                            "does not match the current offset {}", tp, fetchOffset, position);
-                } else {
-                    handleOffsetOutOfRange(position, tp);
-                }
-            } else {
-                log.debug("Unset the preferred read replica {} for partition {} since we got {} when fetching {}",
-                        clearedReplicaId.get(), tp, error, fetchOffset);
-            }
-        } else if (error == Errors.TOPIC_AUTHORIZATION_FAILED) {
-            //we log the actual partition and not just the topic to help with ACL propagation issues in large clusters
-            log.warn("Not authorized to read from partition {}.", tp);
-            throw new TopicAuthorizationException(Collections.singleton(tp.topic()));
-        } else if (error == Errors.UNKNOWN_LEADER_EPOCH) {
-            log.debug("Received unknown leader epoch error in fetch for partition {}", tp);
-        } else if (error == Errors.UNKNOWN_SERVER_ERROR) {
-            log.warn("Unknown server error while fetching offset {} for topic-partition {}",
-                    fetchOffset, tp);
-        } else if (error == Errors.CORRUPT_MESSAGE) {
-            throw new KafkaException("Encountered corrupt message when fetching offset "
-                    + fetchOffset
-                    + " for topic-partition "
-                    + tp);
-        } else {
-            throw new IllegalStateException("Unexpected error code "
-                    + error.code()
-                    + " while fetching at offset "
-                    + fetchOffset
-                    + " from topic-partition " + tp);
-        }
-    }
-
-    private void handleOffsetOutOfRange(final SubscriptionState.FetchPosition fetchPosition,
-                                        final TopicPartition topicPartition) {
-        String errorMessage = "Fetch position " + fetchPosition + " is out of range for partition " + topicPartition;
-
-        if (subscriptions.hasDefaultOffsetResetPolicy()) {
-            log.info("{}, resetting offset", errorMessage);
-            subscriptions.requestOffsetReset(topicPartition);
-        } else {
-            log.info("{}, raising error to the application since no reset policy is configured", errorMessage);
-            throw new OffsetOutOfRangeException(errorMessage,
-                    Collections.singletonMap(topicPartition, fetchPosition.offset));
-        }
-    }
-
-    /**
-     * Clear the buffered data which are not a part of newly assigned partitions. Any previously
-     * {@link CompletedFetch fetched data} is dropped if it is for a partition that is no longer in
-     * {@code assignedPartitions}.
-     *
-     * @param assignedPartitions Newly-assigned {@link TopicPartition}
-     */
-    public void clearBufferedDataForUnassignedPartitions(final Collection<TopicPartition> assignedPartitions) {
-        final Iterator<CompletedFetch<K, V>> completedFetchesItr = completedFetches.iterator();
-
-        while (completedFetchesItr.hasNext()) {
-            final CompletedFetch<K, V> completedFetch = completedFetchesItr.next();
-            final TopicPartition tp = completedFetch.partition;
-
-            if (!assignedPartitions.contains(tp)) {
-                log.debug("Removing {} from buffered data as it is no longer an assigned partition", tp);
-                completedFetch.drain();
-                completedFetchesItr.remove();
-            }
-        }
-
-        if (nextInLineFetch != null && !assignedPartitions.contains(nextInLineFetch.partition)) {
-            nextInLineFetch.drain();
-            nextInLineFetch = null;
-        }
-    }
-
-    /**
-     * Clear the buffered data which are not a part of newly assigned topics
-     *
-     * @param assignedTopics  newly assigned topics
-     */
-    public void clearBufferedDataForUnassignedTopics(Collection<String> assignedTopics) {
-        final Set<TopicPartition> currentTopicPartitions = new HashSet<>();
-
-        for (TopicPartition tp : subscriptions.assignedPartitions()) {
-            if (assignedTopics.contains(tp.topic())) {
-                currentTopicPartitions.add(tp);
-            }
-        }
-
-        clearBufferedDataForUnassignedPartitions(currentTopicPartitions);
-    }
-
     protected FetchSessionHandler sessionHandler(int node) {
         return sessionHandlers.get(node);
     }
 
     // Visible for testing
-    void maybeCloseFetchSessions(final Timer timer) {
-        final Cluster cluster = metadata.fetch();
-        final List<RequestFuture<ClientResponse>> requestFutures = new ArrayList<>();
 
-        sessionHandlers.forEach((fetchTargetNodeId, sessionHandler) -> {
-            // set the session handler to notify close. This will set the next metadata request to send close message.
-            sessionHandler.notifyClose();
-
-            final int sessionId = sessionHandler.sessionId();
-            // FetchTargetNode may not be available as it may have disconnected the connection. In such cases, we will
-            // skip sending the close request.
-            final Node fetchTarget = cluster.nodeById(fetchTargetNodeId);
-            if (fetchTarget == null || client.isUnavailable(fetchTarget)) {
-                log.debug("Skip sending close session request to broker {} since it is not reachable", fetchTarget);
-                return;
-            }
-
-            final FetchRequest.Builder request = createFetchRequest(fetchTarget, sessionHandler.newBuilder().build());
-            final RequestFuture<ClientResponse> responseFuture = client.send(fetchTarget, request);
-
-            responseFuture.addListener(new RequestFutureListener<ClientResponse>() {
-                @Override
-                public void onSuccess(ClientResponse value) {
-                    log.debug("Successfully sent a close message for fetch session: {} to node: {}", sessionId, fetchTarget);
-                }
-
-                @Override
-                public void onFailure(RuntimeException e) {
-                    log.debug("Unable to a close message for fetch session: {} to node: {}. " +
-                            "This may result in unnecessary fetch sessions at the broker.", sessionId, fetchTarget, e);
-                }
-            });
-
-            requestFutures.add(responseFuture);
-        });
-
-        // Poll to ensure that request has been written to the socket. Wait until either the timer has expired or until
-        // all requests have received a response.
-        while (timer.notExpired() && !requestFutures.stream().allMatch(RequestFuture::isDone)) {
-            client.poll(timer, null, true);
-        }
-
-        if (!requestFutures.stream().allMatch(RequestFuture::isDone)) {
-            // we ran out of time before completing all futures. It is ok since we don't want to block the shutdown
-            // here.
-            log.debug("All requests couldn't be sent in the specific timeout period {}ms. " +
-                    "This may result in unnecessary fetch sessions at the broker. Consider increasing the timeout passed for " +
-                    "KafkaConsumer.close(Duration timeout)", timer.timeoutMs());
-        }
-    }
+    /**
+     * This is guaranteed (by the {@link IdempotentCloser} to be executed only once the first time that
+     * any of the {@link #close()} methods are called.
+     * @param timer Timer to enforce time limit
+     */
+    protected abstract void closeInternal(Timer timer);
 
     public void close(final Timer timer) {
-        // we do not need to re-enable wakeups since we are closing already
-        client.disableWakeups();
-
-        if (nextInLineFetch != null) {
-            nextInLineFetch.drain();
-            nextInLineFetch = null;
-        }
-
-        maybeCloseFetchSessions(timer);
-        Utils.closeQuietly(decompressionBufferSupplier, "decompressionBufferSupplier");
-        sessionHandlers.clear();
+        idempotentCloser.close(() -> closeInternal(timer));
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetchBuffer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetchBuffer.java
@@ -97,7 +97,7 @@ public class FetchBuffer<K, V> implements Closeable {
 
     /**
      * Updates the buffer to retain only the fetch data that corresponds to the given partitions. Any previously
-     * {@link CompletedFetch fetched data} is its partition is not in the given set of partitions.
+     * {@link CompletedFetch fetched data} is removed if its partition is not in the given set of partitions.
      *
      * @param partitions {@link Set} of {@link TopicPartition}s for which any buffered data should be kept
      */

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetchBuffer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetchBuffer.java
@@ -32,6 +32,10 @@ import java.util.function.Predicate;
  * {@code FetchBuffer} buffers up the results from the broker responses as they are received. It is essentially a
  * wrapper around a {@link java.util.Queue} of {@link CompletedFetch}.
  *
+ * <p/>
+ *
+ * <em>Note</em>: this class is not thread-safe and is intended to only be used from a single thread.
+ *
  * @param <K> Record key type
  * @param <V> Record value type
  */

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetchBuffer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetchBuffer.java
@@ -53,11 +53,11 @@ public class FetchBuffer<K, V> implements Closeable {
     }
 
     /**
-     * Returns {@code true} of there are no completed fetches pending to return to the user.
+     * Returns {@code true} if there are no completed fetches pending to return to the user.
      *
      * @return {@code true} if the buffer is empty, {@code false} otherwise
      */
-    public boolean isEmpty() {
+    boolean isEmpty() {
         return completedFetches.isEmpty();
     }
 
@@ -67,31 +67,31 @@ public class FetchBuffer<K, V> implements Closeable {
      *
      * @return {@code true} if there are completed fetches that match the {@link Predicate}, {@code false} otherwise
      */
-    public boolean hasCompletedFetches(Predicate<CompletedFetch<K, V>> predicate) {
+    boolean hasCompletedFetches(Predicate<CompletedFetch<K, V>> predicate) {
         return completedFetches.stream().anyMatch(predicate);
     }
 
-    public void add(CompletedFetch<K, V> completedFetch) {
+    void add(CompletedFetch<K, V> completedFetch) {
         completedFetches.add(completedFetch);
     }
 
-    public void addAll(Collection<CompletedFetch<K, V>> completedFetches) {
+    void addAll(Collection<CompletedFetch<K, V>> completedFetches) {
         this.completedFetches.addAll(completedFetches);
     }
 
-    public CompletedFetch<K, V> nextInLineFetch() {
+    CompletedFetch<K, V> nextInLineFetch() {
         return nextInLineFetch;
     }
 
-    public void setNextInLineFetch(CompletedFetch<K, V> completedFetch) {
+    void setNextInLineFetch(CompletedFetch<K, V> completedFetch) {
         this.nextInLineFetch = completedFetch;
     }
 
-    public CompletedFetch<K, V> peek() {
+    CompletedFetch<K, V> peek() {
         return completedFetches.peek();
     }
 
-    public CompletedFetch<K, V> poll() {
+    CompletedFetch<K, V> poll() {
         return completedFetches.poll();
     }
 
@@ -101,7 +101,7 @@ public class FetchBuffer<K, V> implements Closeable {
      *
      * @param partitions {@link Set} of {@link TopicPartition}s for which any buffered data should be kept
      */
-    public void retainAll(final Set<TopicPartition> partitions) {
+    void retainAll(final Set<TopicPartition> partitions) {
         final Iterator<CompletedFetch<K, V>> completedFetchesItr = completedFetches.iterator();
 
         while (completedFetchesItr.hasNext()) {
@@ -121,7 +121,7 @@ public class FetchBuffer<K, V> implements Closeable {
         }
     }
 
-    public Set<TopicPartition> partitions() {
+    Set<TopicPartition> partitions() {
         Set<TopicPartition> partitions = new HashSet<>();
 
         if (nextInLineFetch != null && !nextInLineFetch.isConsumed()) {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetchBuffer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetchBuffer.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer.internals;
+
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.utils.LogContext;
+import org.slf4j.Logger;
+
+import java.io.Closeable;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.function.Predicate;
+
+/**
+ * {@code FetchBuffer} buffers up the results from the broker responses as they are received. It is essentially a
+ * wrapper around a {@link java.util.Queue} of {@link CompletedFetch}.
+ *
+ * @param <K> Record key type
+ * @param <V> Record value type
+ */
+public class FetchBuffer<K, V> implements Closeable {
+
+    private final Logger log;
+    private final ConcurrentLinkedQueue<CompletedFetch<K, V>> completedFetches;
+    private final IdempotentCloser idempotentCloser = new IdempotentCloser();
+
+    private CompletedFetch<K, V> nextInLineFetch;
+
+    public FetchBuffer(final LogContext logContext) {
+        this.log = logContext.logger(FetchBuffer.class);
+        this.completedFetches = new ConcurrentLinkedQueue<>();
+    }
+
+    /**
+     * Returns {@code true} of there are no completed fetches pending to return to the user.
+     *
+     * @return {@code true} if the buffer is empty, {@code false} otherwise
+     */
+    public boolean isEmpty() {
+        return completedFetches.isEmpty();
+    }
+
+    /**
+     * Return whether we have any completed fetches pending return to the user. This method is thread-safe. Has
+     * visibility for testing.
+     *
+     * @return {@code true} if there are completed fetches that match the {@link Predicate}, {@code false} otherwise
+     */
+    public boolean hasCompletedFetches(Predicate<CompletedFetch<K, V>> predicate) {
+        return completedFetches.stream().anyMatch(predicate);
+    }
+
+    public void add(CompletedFetch<K, V> completedFetch) {
+        completedFetches.add(completedFetch);
+    }
+
+    public void addAll(Collection<CompletedFetch<K, V>> completedFetches) {
+        this.completedFetches.addAll(completedFetches);
+    }
+
+    public CompletedFetch<K, V> nextInLineFetch() {
+        return nextInLineFetch;
+    }
+
+    public void setNextInLineFetch(CompletedFetch<K, V> completedFetch) {
+        this.nextInLineFetch = completedFetch;
+    }
+
+    public CompletedFetch<K, V> peek() {
+        return completedFetches.peek();
+    }
+
+    public CompletedFetch<K, V> poll() {
+        return completedFetches.poll();
+    }
+
+    /**
+     * Updates the buffer to retain only the fetch data that corresponds to the given partitions. Any previously
+     * {@link CompletedFetch fetched data} is its partition is not in the given set of partitions.
+     *
+     * @param partitions {@link Set} of {@link TopicPartition}s for which any buffered data should be kept
+     */
+    public void retainAll(final Set<TopicPartition> partitions) {
+        final Iterator<CompletedFetch<K, V>> completedFetchesItr = completedFetches.iterator();
+
+        while (completedFetchesItr.hasNext()) {
+            final CompletedFetch<K, V> completedFetch = completedFetchesItr.next();
+
+            if (!partitions.contains(completedFetch.partition)) {
+                log.debug("Removing {} from buffered fetch data as it is not in the set of partitions to retain", completedFetch.partition);
+                completedFetch.drain();
+                completedFetchesItr.remove();
+            }
+        }
+
+        if (nextInLineFetch != null && !partitions.contains(nextInLineFetch.partition)) {
+            log.debug("Removing {} from buffered fetch data as it is not in the set of partitions to retain", nextInLineFetch.partition);
+            nextInLineFetch.drain();
+            nextInLineFetch = null;
+        }
+    }
+
+    public Set<TopicPartition> partitions() {
+        Set<TopicPartition> partitions = new HashSet<>();
+
+        if (nextInLineFetch != null && !nextInLineFetch.isConsumed()) {
+            partitions.add(nextInLineFetch.partition);
+        }
+
+        for (CompletedFetch<K, V> completedFetch : completedFetches) {
+            partitions.add(completedFetch.partition);
+        }
+
+        return partitions;
+    }
+
+    @Override
+    public void close() {
+        idempotentCloser.close(() -> {
+            log.debug("Closing the fetch buffer");
+
+            if (nextInLineFetch != null) {
+                nextInLineFetch.drain();
+                nextInLineFetch = null;
+            }
+        }, () -> log.warn("The fetch buffer was previously closed"));
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetchCollector.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetchCollector.java
@@ -143,7 +143,7 @@ public class FetchCollector<K, V> {
         return fetch;
     }
 
-    Fetch<K, V> fetchRecords(final CompletedFetch<K, V> nextInLineFetch) {
+    private Fetch<K, V> fetchRecords(final CompletedFetch<K, V> nextInLineFetch) {
         final TopicPartition tp = nextInLineFetch.partition;
 
         if (!subscriptions.isAssigned(tp)) {
@@ -205,7 +205,7 @@ public class FetchCollector<K, V> {
     /**
      * Initialize a CompletedFetch object.
      */
-    CompletedFetch<K, V> initialize(final CompletedFetch<K, V> completedFetch) {
+    protected CompletedFetch<K, V> initialize(final CompletedFetch<K, V> completedFetch) {
         final TopicPartition tp = completedFetch.partition;
         final Errors error = Errors.forCode(completedFetch.partitionData.errorCode());
         boolean recordMetrics = true;
@@ -235,7 +235,7 @@ public class FetchCollector<K, V> {
         }
     }
 
-    CompletedFetch<K, V> handleInitializeSuccess(final CompletedFetch<K, V> completedFetch) {
+    private CompletedFetch<K, V> handleInitializeSuccess(final CompletedFetch<K, V> completedFetch) {
         final TopicPartition tp = completedFetch.partition;
         final long fetchOffset = completedFetch.nextFetchOffset();
 
@@ -299,7 +299,7 @@ public class FetchCollector<K, V> {
         return completedFetch;
     }
 
-    void handleInitializeErrors(final CompletedFetch<K, V> completedFetch, final Errors error) {
+    private void handleInitializeErrors(final CompletedFetch<K, V> completedFetch, final Errors error) {
         final TopicPartition tp = completedFetch.partition;
         final long fetchOffset = completedFetch.nextFetchOffset();
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetchCollector.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetchCollector.java
@@ -1,0 +1,381 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer.internals;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.OffsetOutOfRangeException;
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.RecordTooLargeException;
+import org.apache.kafka.common.errors.TopicAuthorizationException;
+import org.apache.kafka.common.message.FetchResponseData;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.record.RecordBatch;
+import org.apache.kafka.common.requests.FetchResponse;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.Time;
+import org.slf4j.Logger;
+
+import java.util.ArrayDeque;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Queue;
+
+/**
+ * {@code FetchCollector} operates at the {@link RecordBatch} level, as that is what is stored in the
+ * {@link FetchBuffer}. Each {@link org.apache.kafka.common.record.Record} in the {@link RecordBatch} is converted
+ * to a {@link ConsumerRecord} and added to the returned {@link Fetch}.
+ *
+ * @param <K> Record key type
+ * @param <V> Record value type
+ */
+public class FetchCollector<K, V> {
+
+    private final Logger log;
+    private final ConsumerMetadata metadata;
+    private final SubscriptionState subscriptions;
+    private final FetchConfig<K, V> fetchConfig;
+    private final FetchMetricsManager metricsManager;
+    private final Time time;
+
+    public FetchCollector(final LogContext logContext,
+                          final ConsumerMetadata metadata,
+                          final SubscriptionState subscriptions,
+                          final FetchConfig<K, V> fetchConfig,
+                          final FetchMetricsManager metricsManager,
+                          final Time time) {
+        this.log = logContext.logger(FetchCollector.class);
+        this.metadata = metadata;
+        this.subscriptions = subscriptions;
+        this.fetchConfig = fetchConfig;
+        this.metricsManager = metricsManager;
+        this.time = time;
+    }
+
+    /**
+     * Return the fetched {@link ConsumerRecord records}, empty the {@link FetchBuffer record buffer}, and
+     * update the consumed position.
+     *
+     * </p>
+     *
+     * NOTE: returning an {@link Fetch#empty() empty} fetch guarantees the consumed position is not updated.
+     *
+     * @param fetchBuffer {@link FetchBuffer} from which to retrieve the {@link ConsumerRecord records}
+     *
+     * @return A {@link Fetch} for the requested partitions
+     * @throws OffsetOutOfRangeException If there is OffsetOutOfRange error in fetchResponse and
+     *         the defaultResetPolicy is NONE
+     * @throws TopicAuthorizationException If there is TopicAuthorization error in fetchResponse.
+     */
+    public Fetch<K, V> collectFetch(final FetchBuffer<K, V> fetchBuffer) {
+        final Fetch<K, V> fetch = Fetch.empty();
+        final Queue<CompletedFetch<K, V>> pausedCompletedFetches = new ArrayDeque<>();
+        int recordsRemaining = fetchConfig.maxPollRecords;
+
+        try {
+            while (recordsRemaining > 0) {
+                final CompletedFetch<K, V> nextInLineFetch = fetchBuffer.nextInLineFetch();
+
+                if (nextInLineFetch == null || nextInLineFetch.isConsumed()) {
+                    final CompletedFetch<K, V> records = fetchBuffer.peek();
+
+                    if (records == null)
+                        break;
+
+                    if (!records.isInitialized()) {
+                        try {
+                            fetchBuffer.setNextInLineFetch(initializeCompletedFetch(records));
+                        } catch (Exception e) {
+                            // Remove a completedFetch upon a parse with exception if (1) it contains no records, and
+                            // (2) there are no fetched records with actual content preceding this exception.
+                            // The first condition ensures that the completedFetches is not stuck with the same completedFetch
+                            // in cases such as the TopicAuthorizationException, and the second condition ensures that no
+                            // potential data loss due to an exception in a following record.
+                            if (fetch.isEmpty() && FetchResponse.recordsOrFail(records.partitionData).sizeInBytes() == 0)
+                                fetchBuffer.poll();
+
+                            throw e;
+                        }
+                    } else {
+                        fetchBuffer.setNextInLineFetch(records);
+                    }
+
+                    fetchBuffer.poll();
+                } else if (subscriptions.isPaused(nextInLineFetch.partition)) {
+                    // when the partition is paused we add the records back to the completedFetches queue instead of draining
+                    // them so that they can be returned on a subsequent poll if the partition is resumed at that time
+                    log.debug("Skipping fetching records for assigned partition {} because it is paused", nextInLineFetch.partition);
+                    pausedCompletedFetches.add(nextInLineFetch);
+                    fetchBuffer.setNextInLineFetch(null);
+                } else {
+                    final Fetch<K, V> nextFetch = fetchRecords(nextInLineFetch);
+                    recordsRemaining -= nextFetch.numRecords();
+                    fetch.add(nextFetch);
+                }
+            }
+        } catch (KafkaException e) {
+            if (fetch.isEmpty())
+                throw e;
+        } finally {
+            // add any polled completed fetches for paused partitions back to the completed fetches queue to be
+            // re-evaluated in the next poll
+            fetchBuffer.addAll(pausedCompletedFetches);
+        }
+
+        return fetch;
+    }
+
+    private Fetch<K, V> fetchRecords(final CompletedFetch<K, V> nextInLineFetch) {
+        final TopicPartition tp = nextInLineFetch.partition;
+
+        if (!subscriptions.isAssigned(tp)) {
+            // this can happen when a rebalance happened before fetched records are returned to the consumer's poll call
+            log.debug("Not returning fetched records for partition {} since it is no longer assigned", tp);
+        } else if (!subscriptions.isFetchable(tp)) {
+            // this can happen when a partition is paused before fetched records are returned to the consumer's
+            // poll call or if the offset is being reset
+            log.debug("Not returning fetched records for assigned partition {} since it is no longer fetchable", tp);
+        } else {
+            SubscriptionState.FetchPosition position = subscriptions.position(tp);
+
+            if (position == null)
+                throw new IllegalStateException("Missing position for fetchable partition " + tp);
+
+            if (nextInLineFetch.nextFetchOffset() == position.offset) {
+                List<ConsumerRecord<K, V>> partRecords = nextInLineFetch.fetchRecords(fetchConfig.maxPollRecords);
+
+                log.trace("Returning {} fetched records at offset {} for assigned partition {}",
+                        partRecords.size(), position, tp);
+
+                boolean positionAdvanced = false;
+
+                if (nextInLineFetch.nextFetchOffset() > position.offset) {
+                    SubscriptionState.FetchPosition nextPosition = new SubscriptionState.FetchPosition(
+                            nextInLineFetch.nextFetchOffset(),
+                            nextInLineFetch.lastEpoch(),
+                            position.currentLeader);
+                    log.trace("Updating fetch position from {} to {} for partition {} and returning {} records from `poll()`",
+                            position, nextPosition, tp, partRecords.size());
+                    subscriptions.position(tp, nextPosition);
+                    positionAdvanced = true;
+                }
+
+                Long partitionLag = subscriptions.partitionLag(tp, fetchConfig.isolationLevel);
+                if (partitionLag != null)
+                    metricsManager.recordPartitionLag(tp, partitionLag);
+
+                Long lead = subscriptions.partitionLead(tp);
+                if (lead != null) {
+                    metricsManager.recordPartitionLead(tp, lead);
+                }
+
+                return Fetch.forPartition(tp, partRecords, positionAdvanced);
+            } else {
+                // these records aren't next in line based on the last consumed position, ignore them
+                // they must be from an obsolete request
+                log.debug("Ignoring fetched records for {} at offset {} since the current position is {}",
+                        tp, nextInLineFetch.nextFetchOffset(), position);
+            }
+        }
+
+        log.trace("Draining fetched records for partition {}", tp);
+        nextInLineFetch.drain();
+
+        return Fetch.empty();
+    }
+
+
+    /**
+     * Initialize a CompletedFetch object.
+     */
+    private CompletedFetch<K, V> initializeCompletedFetch(final CompletedFetch<K, V> completedFetch) {
+        final TopicPartition tp = completedFetch.partition;
+        final Errors error = Errors.forCode(completedFetch.partitionData.errorCode());
+        boolean recordMetrics = true;
+
+        try {
+            if (!subscriptions.hasValidPosition(tp)) {
+                // this can happen when a rebalance happened while fetch is still in-flight
+                log.debug("Ignoring fetched records for partition {} since it no longer has valid position", tp);
+                return null;
+            } else if (error == Errors.NONE) {
+                final CompletedFetch<K, V> ret = handleInitializeCompletedFetchSuccess(subscriptions, completedFetch);
+                recordMetrics = ret == null;
+                return ret;
+            } else {
+                handleInitializeCompletedFetchErrors(subscriptions, completedFetch, error);
+                return null;
+            }
+        } finally {
+            if (recordMetrics) {
+                completedFetch.recordAggregatedMetrics(0, 0);
+            }
+
+            if (error != Errors.NONE)
+                // we move the partition to the end if there was an error. This way, it's more likely that partitions for
+                // the same topic can remain together (allowing for more efficient serialization).
+                subscriptions.movePartitionToEnd(tp);
+        }
+    }
+
+    private CompletedFetch<K, V> handleInitializeCompletedFetchSuccess(final SubscriptionState subscriptions,
+                                                                       final CompletedFetch<K, V> completedFetch) {
+        final TopicPartition tp = completedFetch.partition;
+        final long fetchOffset = completedFetch.nextFetchOffset();
+
+        // we are interested in this fetch only if the beginning offset matches the
+        // current consumed position
+        SubscriptionState.FetchPosition position = subscriptions.position(tp);
+        if (position == null || position.offset != fetchOffset) {
+            log.debug("Discarding stale fetch response for partition {} since its offset {} does not match " +
+                    "the expected offset {}", tp, fetchOffset, position);
+            return null;
+        }
+
+        final FetchResponseData.PartitionData partition = completedFetch.partitionData;
+        log.trace("Preparing to read {} bytes of data for partition {} with offset {}",
+                FetchResponse.recordsSize(partition), tp, position);
+        Iterator<? extends RecordBatch> batches = FetchResponse.recordsOrFail(partition).batches().iterator();
+
+        if (!batches.hasNext() && FetchResponse.recordsSize(partition) > 0) {
+            if (completedFetch.requestVersion < 3) {
+                // Implement the pre KIP-74 behavior of throwing a RecordTooLargeException.
+                Map<TopicPartition, Long> recordTooLargePartitions = Collections.singletonMap(tp, fetchOffset);
+                throw new RecordTooLargeException("There are some messages at [Partition=Offset]: " +
+                        recordTooLargePartitions + " whose size is larger than the fetch size " + fetchConfig.fetchSize +
+                        " and hence cannot be returned. Please considering upgrading your broker to 0.10.1.0 or " +
+                        "newer to avoid this issue. Alternately, increase the fetch size on the client (using " +
+                        ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG + ")",
+                        recordTooLargePartitions);
+            } else {
+                // This should not happen with brokers that support FetchRequest/Response V3 or higher (i.e. KIP-74)
+                throw new KafkaException("Failed to make progress reading messages at " + tp + "=" +
+                        fetchOffset + ". Received a non-empty fetch response from the server, but no " +
+                        "complete records were found.");
+            }
+        }
+
+        if (partition.highWatermark() >= 0) {
+            log.trace("Updating high watermark for partition {} to {}", tp, partition.highWatermark());
+            subscriptions.updateHighWatermark(tp, partition.highWatermark());
+        }
+
+        if (partition.logStartOffset() >= 0) {
+            log.trace("Updating log start offset for partition {} to {}", tp, partition.logStartOffset());
+            subscriptions.updateLogStartOffset(tp, partition.logStartOffset());
+        }
+
+        if (partition.lastStableOffset() >= 0) {
+            log.trace("Updating last stable offset for partition {} to {}", tp, partition.lastStableOffset());
+            subscriptions.updateLastStableOffset(tp, partition.lastStableOffset());
+        }
+
+        if (FetchResponse.isPreferredReplica(partition)) {
+            subscriptions.updatePreferredReadReplica(completedFetch.partition, partition.preferredReadReplica(), () -> {
+                long expireTimeMs = time.milliseconds() + metadata.metadataExpireMs();
+                log.debug("Updating preferred read replica for partition {} to {}, set to expire at {}",
+                        tp, partition.preferredReadReplica(), expireTimeMs);
+                return expireTimeMs;
+            });
+        }
+
+        completedFetch.setInitialized();
+        return completedFetch;
+    }
+
+    private void handleInitializeCompletedFetchErrors(final SubscriptionState subscriptions,
+                                                      final CompletedFetch<K, V> completedFetch,
+                                                      final Errors error) {
+        final TopicPartition tp = completedFetch.partition;
+        final long fetchOffset = completedFetch.nextFetchOffset();
+
+        if (error == Errors.NOT_LEADER_OR_FOLLOWER ||
+                error == Errors.REPLICA_NOT_AVAILABLE ||
+                error == Errors.KAFKA_STORAGE_ERROR ||
+                error == Errors.FENCED_LEADER_EPOCH ||
+                error == Errors.OFFSET_NOT_AVAILABLE) {
+            log.debug("Error in fetch for partition {}: {}", tp, error.exceptionName());
+            FetchUtils.requestMetadataUpdate(metadata, subscriptions, tp);
+        } else if (error == Errors.UNKNOWN_TOPIC_OR_PARTITION) {
+            log.warn("Received unknown topic or partition error in fetch for partition {}", tp);
+            FetchUtils.requestMetadataUpdate(metadata, subscriptions, tp);
+        } else if (error == Errors.UNKNOWN_TOPIC_ID) {
+            log.warn("Received unknown topic ID error in fetch for partition {}", tp);
+            FetchUtils.requestMetadataUpdate(metadata, subscriptions, tp);
+        } else if (error == Errors.INCONSISTENT_TOPIC_ID) {
+            log.warn("Received inconsistent topic ID error in fetch for partition {}", tp);
+            FetchUtils.requestMetadataUpdate(metadata, subscriptions, tp);
+        } else if (error == Errors.OFFSET_OUT_OF_RANGE) {
+            Optional<Integer> clearedReplicaId = subscriptions.clearPreferredReadReplica(tp);
+
+            if (!clearedReplicaId.isPresent()) {
+                // If there's no preferred replica to clear, we're fetching from the leader so handle this error normally
+                SubscriptionState.FetchPosition position = subscriptions.position(tp);
+
+                if (position == null || fetchOffset != position.offset) {
+                    log.debug("Discarding stale fetch response for partition {} since the fetched offset {} " +
+                            "does not match the current offset {}", tp, fetchOffset, position);
+                } else {
+                    handleOffsetOutOfRange(subscriptions, position, tp);
+                }
+            } else {
+                log.debug("Unset the preferred read replica {} for partition {} since we got {} when fetching {}",
+                        clearedReplicaId.get(), tp, error, fetchOffset);
+            }
+        } else if (error == Errors.TOPIC_AUTHORIZATION_FAILED) {
+            //we log the actual partition and not just the topic to help with ACL propagation issues in large clusters
+            log.warn("Not authorized to read from partition {}.", tp);
+            throw new TopicAuthorizationException(Collections.singleton(tp.topic()));
+        } else if (error == Errors.UNKNOWN_LEADER_EPOCH) {
+            log.debug("Received unknown leader epoch error in fetch for partition {}", tp);
+        } else if (error == Errors.UNKNOWN_SERVER_ERROR) {
+            log.warn("Unknown server error while fetching offset {} for topic-partition {}",
+                    fetchOffset, tp);
+        } else if (error == Errors.CORRUPT_MESSAGE) {
+            throw new KafkaException("Encountered corrupt message when fetching offset "
+                    + fetchOffset
+                    + " for topic-partition "
+                    + tp);
+        } else {
+            throw new IllegalStateException("Unexpected error code "
+                    + error.code()
+                    + " while fetching at offset "
+                    + fetchOffset
+                    + " from topic-partition " + tp);
+        }
+    }
+
+
+    private void handleOffsetOutOfRange(final SubscriptionState subscriptions,
+                                        final SubscriptionState.FetchPosition fetchPosition,
+                                        final TopicPartition topicPartition) {
+        String errorMessage = "Fetch position " + fetchPosition + " is out of range for partition " + topicPartition;
+
+        if (subscriptions.hasDefaultOffsetResetPolicy()) {
+            log.info("{}, resetting offset", errorMessage);
+            subscriptions.requestOffsetReset(topicPartition);
+        } else {
+            log.info("{}, raising error to the application since no reset policy is configured", errorMessage);
+            throw new OffsetOutOfRangeException(errorMessage,
+                    Collections.singletonMap(topicPartition, fetchPosition.offset));
+        }
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
@@ -19,14 +19,19 @@ package org.apache.kafka.clients.consumer.internals;
 import org.apache.kafka.clients.ClientResponse;
 import org.apache.kafka.clients.FetchSessionHandler;
 import org.apache.kafka.common.Node;
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.requests.FetchRequest;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Timer;
+import org.apache.kafka.common.utils.Utils;
 import org.slf4j.Logger;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * This class manages the fetching process with the brokers.
@@ -50,7 +55,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class Fetcher<K, V> extends AbstractFetch<K, V> {
 
     private final Logger log;
-    private final AtomicBoolean isClosed = new AtomicBoolean(false);
+    private final FetchCollector<K, V> fetchCollector;
 
     public Fetcher(LogContext logContext,
                    ConsumerNetworkClient client,
@@ -61,6 +66,16 @@ public class Fetcher<K, V> extends AbstractFetch<K, V> {
                    Time time) {
         super(logContext, client, metadata, subscriptions, fetchConfig, metricsManager, time);
         this.log = logContext.logger(Fetcher.class);
+        this.fetchCollector = new FetchCollector<>(logContext,
+                metadata,
+                subscriptions,
+                fetchConfig,
+                metricsManager,
+                time);
+    }
+
+    public void clearBufferedDataForUnassignedPartitions(Collection<TopicPartition> assignedPartitions) {
+        fetchBuffer.retainAll(new HashSet<>(assignedPartitions));
     }
 
     /**
@@ -98,16 +113,71 @@ public class Fetcher<K, V> extends AbstractFetch<K, V> {
         return fetchRequestMap.size();
     }
 
-    public void close(final Timer timer) {
-        if (!isClosed.compareAndSet(false, true)) {
-            log.info("Fetcher {} is already closed.", this);
-            return;
+    public Fetch<K, V> collectFetch() {
+        return fetchCollector.collectFetch(fetchBuffer);
+    }
+
+    public boolean hasCompletedFetches() {
+        return !fetchBuffer.isEmpty();
+    }
+
+    /**
+     * Return whether we have any completed fetches that are fetchable. This method is thread-safe.
+     * @return true if there are completed fetches that can be returned, false otherwise
+     */
+    public boolean hasAvailableFetches() {
+        return fetchBuffer.hasCompletedFetches(fetch -> subscriptions.isFetchable(fetch.partition));
+    }
+
+    protected void maybeCloseFetchSessions(final Timer timer) {
+        final List<RequestFuture<ClientResponse>> requestFutures = new ArrayList<>();
+        Map<Node, FetchSessionHandler.FetchRequestData> fetchRequestMap = prepareCloseFetchSessionRequests();
+
+        for (Map.Entry<Node, FetchSessionHandler.FetchRequestData> entry : fetchRequestMap.entrySet()) {
+            final Node fetchTarget = entry.getKey();
+            final FetchSessionHandler.FetchRequestData data = entry.getValue();
+            final FetchRequest.Builder request = createFetchRequest(fetchTarget, data);
+            final RequestFuture<ClientResponse> responseFuture = client.send(fetchTarget, request);
+
+            responseFuture.addListener(new RequestFutureListener<ClientResponse>() {
+                @Override
+                public void onSuccess(ClientResponse value) {
+                    handleCloseFetchSessionResponse(fetchTarget, data);
+                }
+
+                @Override
+                public void onFailure(RuntimeException e) {
+                    handleCloseFetchSessionResponse(fetchTarget, data, e);
+                }
+            });
+
+            requestFutures.add(responseFuture);
         }
 
+        // Poll to ensure that request has been written to the socket. Wait until either the timer has expired or until
+        // all requests have received a response.
+        while (timer.notExpired() && !requestFutures.stream().allMatch(RequestFuture::isDone)) {
+            client.poll(timer, null, true);
+        }
+
+        if (!requestFutures.stream().allMatch(RequestFuture::isDone)) {
+            // we ran out of time before completing all futures. It is ok since we don't want to block the shutdown
+            // here.
+            log.debug("All requests couldn't be sent in the specific timeout period {}ms. " +
+                    "This may result in unnecessary fetch sessions at the broker. Consider increasing the timeout passed for " +
+                    "KafkaConsumer.close(Duration timeout)", timer.timeoutMs());
+        }
+    }
+
+    @Override
+    protected void closeInternal(final Timer timer) {
         // Shared states (e.g. sessionHandlers) could be accessed by multiple threads (such as heartbeat thread), hence,
         // it is necessary to acquire a lock on the fetcher instance before modifying the states.
         synchronized (this) {
-            super.close(timer);
+            // we do not need to re-enable wakeups since we are closing already
+            client.disableWakeups();
+            maybeCloseFetchSessions(timer);
+            Utils.closeQuietly(decompressionBufferSupplier, "decompressionBufferSupplier");
         }
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
@@ -117,18 +117,6 @@ public class Fetcher<K, V> extends AbstractFetch<K, V> {
         return fetchCollector.collectFetch(fetchBuffer);
     }
 
-    public boolean hasCompletedFetches() {
-        return !fetchBuffer.isEmpty();
-    }
-
-    /**
-     * Return whether we have any completed fetches that are fetchable. This method is thread-safe.
-     * @return true if there are completed fetches that can be returned, false otherwise
-     */
-    public boolean hasAvailableFetches() {
-        return fetchBuffer.hasCompletedFetches(fetch -> subscriptions.isFetchable(fetch.partition));
-    }
-
     protected void maybeCloseFetchSessions(final Timer timer) {
         final List<RequestFuture<ClientResponse>> requestFutures = new ArrayList<>();
         Map<Node, FetchSessionHandler.FetchRequestData> fetchRequestMap = prepareCloseFetchSessionRequests();

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetchBufferTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetchBufferTest.java
@@ -1,0 +1,200 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer.internals;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.message.FetchResponseData;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.common.utils.BufferSupplier;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.common.utils.Time;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Properties;
+import java.util.Set;
+
+import static org.apache.kafka.clients.consumer.internals.Utils.createFetchConfig;
+import static org.apache.kafka.clients.consumer.internals.Utils.createFetchMetricsManager;
+import static org.apache.kafka.clients.consumer.internals.Utils.createMetrics;
+import static org.apache.kafka.clients.consumer.internals.Utils.createSubscriptionState;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * This tests the {@link FetchBuffer} functionality in addition to what {@link FetcherTest} tests during the course
+ * of its tests. One of the main concerns of these tests are that we correctly handle both places that data is held
+ * internally:
+ *
+ * <ol>
+ *     <li>A special "next in line" buffer</li>
+ *     <li>The remainder of the buffers in a queue</li>
+ * </ol>
+ */
+public class FetchBufferTest {
+
+    private final Time time = new MockTime(0, 0, 0);
+    private final TopicPartition topicAPartition0 = new TopicPartition("topic-a", 0);
+    private final TopicPartition topicAPartition1 = new TopicPartition("topic-a", 1);
+    private final TopicPartition topicAPartition2 = new TopicPartition("topic-a", 2);
+    private final Set<TopicPartition> allPartitions = partitions(topicAPartition0, topicAPartition1, topicAPartition2);
+    private LogContext logContext;
+
+    private SubscriptionState subscriptions;
+
+    private FetchConfig<String, String> fetchConfig;
+
+    private FetchMetricsManager metricsManager;
+
+    @BeforeEach
+    public void setup() {
+        logContext = new LogContext();
+
+        Properties p = new Properties();
+        p.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        p.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        p.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        ConsumerConfig config = new ConsumerConfig(p);
+
+        Deserializers<String, String> deserializers = new Deserializers<>(new StringDeserializer(), new StringDeserializer());
+
+        subscriptions = createSubscriptionState(config, logContext);
+        fetchConfig = createFetchConfig(config, deserializers);
+
+        Metrics metrics = createMetrics(config, time);
+        metricsManager = createFetchMetricsManager(metrics);
+    }
+
+    /**
+     * Verifies the basics: we can add buffered data to the queue, peek to view them, and poll to remove them.
+     */
+    @Test
+    public void testBasicPeekAndPoll() {
+        try (FetchBuffer<String, String> fetchBuffer = new FetchBuffer<>(logContext)) {
+            CompletedFetch<String, String> completedFetch = completedFetch(topicAPartition0);
+            assertTrue(fetchBuffer.isEmpty());
+            fetchBuffer.add(completedFetch);
+            assertTrue(fetchBuffer.hasCompletedFetches(p -> true));
+            assertFalse(fetchBuffer.isEmpty());
+            assertNotNull(fetchBuffer.peek());
+            assertEquals(completedFetch, fetchBuffer.peek());   // Reference equality
+            assertEquals(completedFetch, fetchBuffer.poll());   // Reference equality
+            assertNull(fetchBuffer.peek());
+        }
+    }
+
+    /**
+     * Verifies {@link FetchBuffer#close()}} closes the buffered data for both the queue and the next-in-line buffer.
+     */
+    @Test
+    public void testCloseClearsData() {
+        FetchBuffer<String, String> fetchBuffer = null;
+
+        try {
+            fetchBuffer = new FetchBuffer<>(logContext);
+            assertNull(fetchBuffer.nextInLineFetch());
+            assertTrue(fetchBuffer.isEmpty());
+
+            fetchBuffer.add(completedFetch(topicAPartition0));
+            assertFalse(fetchBuffer.isEmpty());
+
+            fetchBuffer.setNextInLineFetch(completedFetch(topicAPartition0));
+            assertNotNull(fetchBuffer.nextInLineFetch());
+        } finally {
+            if (fetchBuffer != null)
+                fetchBuffer.close();
+        }
+
+        assertNull(fetchBuffer.nextInLineFetch());
+        assertTrue(fetchBuffer.isEmpty());
+    }
+
+    /**
+     * Tests that the buffer returns partitions for both the queue and the next-in-line buffer.
+     */
+    @Test
+    public void testPartitions() {
+        try (FetchBuffer<String, String> fetchBuffer = new FetchBuffer<>(logContext)) {
+            fetchBuffer.setNextInLineFetch(completedFetch(topicAPartition0));
+            fetchBuffer.add(completedFetch(topicAPartition1));
+            fetchBuffer.add(completedFetch(topicAPartition2));
+            assertEquals(allPartitions, fetchBuffer.partitions());
+
+            fetchBuffer.setNextInLineFetch(null);
+            assertEquals(partitions(topicAPartition1, topicAPartition2), fetchBuffer.partitions());
+
+            fetchBuffer.poll();
+            assertEquals(partitions(topicAPartition2), fetchBuffer.partitions());
+
+            fetchBuffer.poll();
+            assertEquals(partitions(), fetchBuffer.partitions());
+        }
+    }
+
+    /**
+     * Tests that the buffer manipulates partitions for both the queue and the next-in-line buffer.
+     */
+    @Test
+    public void testAddAllAndRetainAll() {
+        try (FetchBuffer<String, String> fetchBuffer = new FetchBuffer<>(logContext)) {
+            fetchBuffer.setNextInLineFetch(completedFetch(topicAPartition0));
+            fetchBuffer.addAll(Arrays.asList(completedFetch(topicAPartition1), completedFetch(topicAPartition2)));
+            assertEquals(allPartitions, fetchBuffer.partitions());
+
+            fetchBuffer.retainAll(partitions(topicAPartition1, topicAPartition2));
+            assertEquals(partitions(topicAPartition1, topicAPartition2), fetchBuffer.partitions());
+
+            fetchBuffer.retainAll(partitions(topicAPartition2));
+            assertEquals(partitions(topicAPartition2), fetchBuffer.partitions());
+
+            fetchBuffer.retainAll(partitions());
+            assertEquals(partitions(), fetchBuffer.partitions());
+        }
+    }
+
+    private CompletedFetch<String, String> completedFetch(TopicPartition tp) {
+        FetchResponseData.PartitionData partitionData = new FetchResponseData.PartitionData();
+        FetchMetricsAggregator metricsAggregator = new FetchMetricsAggregator(metricsManager, allPartitions);
+        return new CompletedFetch<>(
+                logContext,
+                subscriptions,
+                fetchConfig,
+                BufferSupplier.create(),
+                tp,
+                partitionData,
+                metricsAggregator,
+                0L,
+                ApiKeys.FETCH.latestVersion());
+    }
+
+    /**
+     * This is a handy utility method for returning a set from a varargs array.
+     */
+    private static Set<TopicPartition> partitions(TopicPartition... partitions) {
+        return new HashSet<>(Arrays.asList(partitions));
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetchBufferTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetchBufferTest.java
@@ -43,6 +43,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -101,8 +102,8 @@ public class FetchBufferTest {
             assertTrue(fetchBuffer.hasCompletedFetches(p -> true));
             assertFalse(fetchBuffer.isEmpty());
             assertNotNull(fetchBuffer.peek());
-            assertEquals(completedFetch, fetchBuffer.peek());   // Reference equality
-            assertEquals(completedFetch, fetchBuffer.poll());   // Reference equality
+            assertSame(completedFetch, fetchBuffer.peek());
+            assertSame(completedFetch, fetchBuffer.poll());
             assertNull(fetchBuffer.peek());
         }
     }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetchCollectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetchCollectorTest.java
@@ -1,0 +1,215 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer.internals;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.internals.ClusterResourceListeners;
+import org.apache.kafka.common.message.FetchResponseData;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.record.CompressionType;
+import org.apache.kafka.common.record.MemoryRecords;
+import org.apache.kafka.common.record.MemoryRecordsBuilder;
+import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.common.utils.BufferSupplier;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.common.utils.Time;
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Properties;
+import java.util.Set;
+
+import static org.apache.kafka.clients.consumer.internals.Utils.createFetchConfig;
+import static org.apache.kafka.clients.consumer.internals.Utils.createFetchMetricsManager;
+import static org.apache.kafka.clients.consumer.internals.Utils.createMetrics;
+import static org.apache.kafka.clients.consumer.internals.Utils.createSubscriptionState;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * This tests the {@link FetchCollector} functionality in addition to what {@link FetcherTest} tests during the course
+ * of its tests.
+ */
+public class FetchCollectorTest {
+
+    private final Time time = new MockTime(0, 0, 0);
+    private final TopicPartition topicAPartition0 = new TopicPartition("topic-a", 0);
+    private final TopicPartition topicAPartition1 = new TopicPartition("topic-a", 1);
+    private final TopicPartition topicAPartition2 = new TopicPartition("topic-a", 2);
+    private final Set<TopicPartition> allPartitions = partitions(topicAPartition0, topicAPartition1, topicAPartition2);
+    private LogContext logContext;
+
+    private SubscriptionState subscriptions;
+
+    private FetchConfig<String, String> fetchConfig;
+
+    private FetchMetricsManager metricsManager;
+
+    private FetchCollector<String, String> fetchCollector;
+
+    @Test
+    public void testNoResultsIfInitializing() {
+        buildDependencies(ConsumerConfig.DEFAULT_MAX_POLL_RECORDS);
+
+        subscriptions.assignFromUser(partitions(topicAPartition0));
+
+        try (FetchBuffer<String, String> fetchBuffer = new FetchBuffer<>(logContext)) {
+            fetchBuffer.add(completedFetch(1000));
+            Fetch<String, String> fetch = fetchCollector.collectFetch(fetchBuffer);
+            assertEquals(0, fetch.numRecords());
+        }
+    }
+
+    @Test
+    public void testFetchNormal() {
+        int recordCount = 1000;
+        buildDependencies(recordCount);
+
+        subscriptions.assignFromUser(partitions(topicAPartition0));
+        subscriptions.seek(topicAPartition0, 0);
+
+        try (FetchBuffer<String, String> fetchBuffer = new FetchBuffer<>(logContext)) {
+            CompletedFetch<String, String> completedFetch = completedFetch(recordCount);
+
+            // Validate that the buffer is empty until after we add the fetch data.
+            assertTrue(fetchBuffer.isEmpty());
+            fetchBuffer.add(completedFetch);
+            assertFalse(fetchBuffer.isEmpty());
+
+            // Validate that the completed fetch isn't initialized just because we add it to the buffer.
+            assertFalse(completedFetch.isInitialized());
+
+            // Fetch the data and validate that we get all the records we want back.
+            Fetch<String, String> fetch = fetchCollector.collectFetch(fetchBuffer);
+            assertFalse(fetch.isEmpty());
+            assertEquals(recordCount, fetch.numRecords());
+
+            // When we collected the data from the buffer, this will cause the completed fetch to get initialized.
+            assertTrue(completedFetch.isInitialized());
+
+            // However, even though we've collected the data, it isn't (completely) consumed yet.
+            assertFalse(completedFetch.isConsumed());
+
+            // The buffer is now considered "empty" because our queue is empty.
+            assertTrue(fetchBuffer.isEmpty());
+            assertNull(fetchBuffer.peek());
+            assertNull(fetchBuffer.poll());
+
+            // However, while the queue is "empty", the next-in-line fetch is actually still in the buffer.
+            assertNotNull(fetchBuffer.nextInLineFetch());
+
+            // Validate that the next fetch position has been updated to point to the record after our last fetched
+            // record.
+            SubscriptionState.FetchPosition position = subscriptions.position(topicAPartition0);
+            assertEquals(recordCount, position.offset);
+
+            // Now attempt to collect more records from the fetch buffer.
+            fetch = fetchCollector.collectFetch(fetchBuffer);
+
+            // The Fetch object is non-null, but it's empty.
+            assertEquals(0, fetch.numRecords());
+            assertTrue(fetch.isEmpty());
+
+            // However, once we read *past* the end of the records in the CompletedFetch, then we will call
+            // drain on it and it will be considered all consumed.
+            assertTrue(completedFetch.isConsumed());
+        }
+    }
+
+    private CompletedFetch<String, String> completedFetch(int count) {
+        MemoryRecords records = records(0, count, 0);
+        FetchResponseData.PartitionData partitionData = new FetchResponseData.PartitionData()
+                .setPartitionIndex(topicAPartition0.partition())
+                .setHighWatermark(1000)
+                .setRecords(records);
+        return completedFetch(topicAPartition0, partitionData);
+    }
+
+    private CompletedFetch<String, String> completedFetch(TopicPartition tp, FetchResponseData.PartitionData partitionData) {
+        FetchMetricsAggregator metricsAggregator = new FetchMetricsAggregator(metricsManager, allPartitions);
+        return new CompletedFetch<>(
+                logContext,
+                subscriptions,
+                fetchConfig,
+                BufferSupplier.create(),
+                tp,
+                partitionData,
+                metricsAggregator,
+                0L,
+                ApiKeys.FETCH.latestVersion());
+    }
+
+    /**
+     * This is a handy utility method for returning a set from a varargs array.
+     */
+    private static Set<TopicPartition> partitions(TopicPartition... partitions) {
+        return new HashSet<>(Arrays.asList(partitions));
+    }
+
+    private MemoryRecords records(long baseOffset, int count, long firstMessageId) {
+        MemoryRecordsBuilder builder = MemoryRecords.builder(ByteBuffer.allocate(1024), CompressionType.NONE, TimestampType.CREATE_TIME, baseOffset);
+        for (int i = 0; i < count; i++)
+            builder.append(0L, "key".getBytes(), ("value-" + (firstMessageId + i)).getBytes());
+        return builder.build();
+    }
+
+    private void buildDependencies(int maxPollRecords) {
+        logContext = new LogContext();
+
+        Properties p = new Properties();
+        p.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        p.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        p.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        p.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, String.valueOf(maxPollRecords));
+
+        ConsumerConfig config = new ConsumerConfig(p);
+
+        Deserializers<String, String> deserializers = new Deserializers<>(new StringDeserializer(), new StringDeserializer());
+
+        subscriptions = createSubscriptionState(config, logContext);
+        fetchConfig = createFetchConfig(config, deserializers);
+
+        Metrics metrics = createMetrics(config, time);
+        metricsManager = createFetchMetricsManager(metrics);
+
+        ConsumerMetadata metadata = new ConsumerMetadata(
+                0,
+                10000,
+                false,
+                false,
+                subscriptions,
+                logContext,
+                new ClusterResourceListeners());
+        fetchCollector = new FetchCollector<>(
+                logContext,
+                metadata,
+                subscriptions,
+                fetchConfig,
+                metricsManager,
+                time);
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetchCollectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetchCollectorTest.java
@@ -197,7 +197,7 @@ public class FetchCollectorTest {
                 time) {
 
             @Override
-            CompletedFetch<String, String> initialize(final CompletedFetch<String, String> completedFetch) {
+            protected CompletedFetch<String, String> initialize(final CompletedFetch<String, String> completedFetch) {
                 throw expectedException;
             }
         };

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/IdempotentCloserTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/IdempotentCloserTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class IdempotentCloserTest {
 
-    private static final Runnable CALLBACK_NO_OP = () -> {};
+    private static final Runnable CALLBACK_NO_OP = () -> { };
 
     private static final Runnable CALLBACK_WITH_RUNTIME_EXCEPTION = () -> {
         throw new RuntimeException("Simulated error during callback");


### PR DESCRIPTION
More abstraction of the `Fetcher` code to split into classes to buffer raw results (`FetchBuffer`) and to collect raw results into `ConsumerRecords` (`FetchCollector`).
