### PR TITLE
KAFKA-14274, #5: introducing NodeStatusDetector

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClientUtils.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClientUtils.java
@@ -127,7 +127,7 @@ public final class NetworkClientUtils {
     /**
      * Check for an authentication error on a given node and raise the exception if there is one.
      */
-    public static void maybeThrowAuthenticationException(KafkaClient client, Node node) {
+    public static void maybeThrowAuthFailure(KafkaClient client, Node node) {
         AuthenticationException exception = client.authenticationException(node);
         if (exception != null)
             throw exception;

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerNetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerNetworkClient.java
@@ -52,7 +52,7 @@ import java.util.concurrent.locks.ReentrantLock;
  * is thread-safe, but provides no synchronization for response callbacks. This guarantees that no locks
  * are held when they are invoked.
  */
-public class ConsumerNetworkClient implements Closeable {
+public class ConsumerNetworkClient implements NodeStatusDetector, Closeable {
     private static final int MAX_POLL_TIMEOUT_MS = 5000;
 
     // the mutable state of this class is protected by the object's monitor (excluding the wakeup
@@ -556,6 +556,7 @@ public class ConsumerNetworkClient implements Closeable {
      * Check if the code is disconnected and unavailable for immediate reconnection (i.e. if it is in
      * reconnect backoff window following the disconnect).
      */
+    @Override
     public boolean isUnavailable(Node node) {
         lock.lock();
         try {
@@ -568,10 +569,11 @@ public class ConsumerNetworkClient implements Closeable {
     /**
      * Check for an authentication error on a given node and raise the exception if there is one.
      */
+    @Override
     public void maybeThrowAuthFailure(Node node) {
         lock.lock();
         try {
-            NetworkClientUtils.maybeThrowAuthenticationException(client, node);
+            NetworkClientUtils.maybeThrowAuthFailure(client, node);
         } finally {
             lock.unlock();
         }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
@@ -56,6 +56,7 @@ public class Fetcher<K, V> extends AbstractFetch<K, V> {
 
     private final Logger log;
     private final FetchCollector<K, V> fetchCollector;
+    private final ConsumerNetworkClient client;
 
     public Fetcher(LogContext logContext,
                    ConsumerNetworkClient client,
@@ -72,6 +73,7 @@ public class Fetcher<K, V> extends AbstractFetch<K, V> {
                 fetchConfig,
                 metricsManager,
                 time);
+        this.client = client;
     }
 
     public void clearBufferedDataForUnassignedPartitions(Collection<TopicPartition> assignedPartitions) {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/NodeStatusDetector.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/NodeStatusDetector.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer.internals;
+
+import org.apache.kafka.clients.KafkaClient;
+import org.apache.kafka.clients.NetworkClientUtils;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.errors.AuthenticationException;
+import org.apache.kafka.common.utils.Time;
+
+/**
+ * Used {@code NodeStatusDetector} to determine the status of a given broker {@link Node}. It's also
+ * possible to check for previous authentication errors if the node isn't available.
+ *
+ * @see ConsumerNetworkClient
+ * @see NetworkClientDelegate
+ */
+public interface NodeStatusDetector {
+
+    /**
+     * Check if the code is disconnected and unavailable for immediate reconnection (i.e. if it is in
+     * reconnect backoff window following the disconnect).
+     *
+     * @param node {@link Node} to check for availability
+     * @see NetworkClientUtils#isUnavailable(KafkaClient, Node, Time)
+     */
+    boolean isUnavailable(Node node);
+
+    /**
+     * Checks for an authentication error on a given node and throws the exception if it exists.
+     *
+     * @param node {@link Node} to check for a previous {@link AuthenticationException}; if found it is thrown
+     * @see NetworkClientUtils#maybeThrowAuthFailure(KafkaClient, Node)
+     */
+    void maybeThrowAuthFailure(Node node);
+}

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/NodeStatusDetector.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/NodeStatusDetector.java
@@ -23,7 +23,7 @@ import org.apache.kafka.common.errors.AuthenticationException;
 import org.apache.kafka.common.utils.Time;
 
 /**
- * Used {@code NodeStatusDetector} to determine the status of a given broker {@link Node}. It's also
+ * Use {@code NodeStatusDetector} to determine the status of a given broker {@link Node}. It's also
  * possible to check for previous authentication errors if the node isn't available.
  *
  * @see ConsumerNetworkClient
@@ -32,7 +32,7 @@ import org.apache.kafka.common.utils.Time;
 public interface NodeStatusDetector {
 
     /**
-     * Check if the code is disconnected and unavailable for immediate reconnection (i.e. if it is in
+     * Check if the node is disconnected and unavailable for immediate reconnection (i.e. if it is in
      * reconnect backoff window following the disconnect).
      *
      * @param node {@link Node} to check for availability


### PR DESCRIPTION
`NodeStatusDetector` is a new interface that abstracts two methods from `ConsumerNetworkClient`: `isUnavailable` and `maybeThrowAuthFailure`. This allows for multiple implementations, though it's presently just `ConsumerNetworkClient` and `NetworkClientDelegate`. This allows shared code in `AbstractFetch` to use that abstracted API instead of using the `ConsumerNetworkClient` directly.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
