### PR TITLE
KAFKA-14274, #6: introducing deferred resource creation

### DIFF
--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -205,6 +205,10 @@
 
     <subpackage name="consumer">
       <allow pkg="org.apache.kafka.clients.consumer" />
+
+      <subpackage name="internals">
+        <allow pkg="org.apache.kafka.clients" />
+      </subpackage>
     </subpackage>
 
     <subpackage name="producer">

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -60,6 +60,8 @@
               files="AbstractRequest.java"/>
     <suppress checks="ClassFanOutComplexity"
               files="AbstractResponse.java"/>
+    <suppress checks="ClassFanOutComplexity"
+              files="PrototypeAsyncConsumer.java"/>
 
     <suppress checks="MethodLength"
               files="(KerberosLogin|RequestResponseTest|ConnectMetricsRegistry|KafkaConsumer|AbstractStickyAssignor).java"/>
@@ -67,7 +69,7 @@
     <suppress checks="ParameterNumber"
               files="(NetworkClient|FieldSpec|KafkaRaftClient).java"/>
     <suppress checks="ParameterNumber"
-              files="(KafkaConsumer|ConsumerCoordinator).java"/>
+              files="(KafkaConsumer|PrototypeAsyncConsumer|ConsumerCoordinator).java"/>
     <suppress checks="ParameterNumber"
               files="Sender.java"/>
     <suppress checks="ParameterNumber"
@@ -107,7 +109,7 @@
 
     <!-- Clients tests -->
     <suppress checks="ClassDataAbstractionCoupling"
-              files="(Sender|Fetcher|OffsetFetcher|KafkaConsumer|Metrics|RequestResponse|TransactionManager|KafkaAdminClient|Message|KafkaProducer)Test.java"/>
+              files="(Sender|Fetcher|OffsetFetcher|KafkaConsumer|PrototypeAsyncConsumer|Metrics|RequestResponse|TransactionManager|KafkaAdminClient|Message|KafkaProducer)Test.java"/>
 
     <suppress checks="ClassFanOutComplexity"
               files="(ConsumerCoordinator|KafkaConsumer|RequestResponse|Fetcher|KafkaAdminClient|Message|KafkaProducer)Test.java"/>

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CachedSupplier.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CachedSupplier.java
@@ -16,20 +16,23 @@
  */
 package org.apache.kafka.clients.consumer.internals;
 
-import org.apache.kafka.clients.consumer.internals.NetworkClientDelegate.PollResult;
-
-import java.io.Closeable;
+import java.util.function.Supplier;
 
 /**
- * {@code PollResult} consist of {@code UnsentRequest} if there are requests to send; otherwise, return the time till
- * the next poll event.
+ * Simple {@link Supplier} that caches the initial creation of the object and stores it for later calls
+ * to {@link #get()}.
  */
-public interface RequestManager extends Closeable {
+public abstract class CachedSupplier<T> implements Supplier<T> {
 
-    PollResult poll(long currentTimeMs);
+    private T result;
+
+    protected abstract T create();
 
     @Override
-    default void close() {
-        // Do nothing...
+    public T get() {
+        if (result == null)
+            result = create();
+
+        return result;
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CachedSupplier.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CachedSupplier.java
@@ -21,6 +21,11 @@ import java.util.function.Supplier;
 /**
  * Simple {@link Supplier} that caches the initial creation of the object and stores it for later calls
  * to {@link #get()}.
+ *
+ * <p/>
+ *
+ * <em>Note</em>: this class is not thread safe! Use only in contexts which are designed/guaranteed to be
+ * single-threaded.
  */
 public abstract class CachedSupplier<T> implements Supplier<T> {
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThread.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThread.java
@@ -16,32 +16,21 @@
  */
 package org.apache.kafka.clients.consumer.internals;
 
-import org.apache.kafka.clients.ApiVersions;
-import org.apache.kafka.clients.ClientUtils;
-import org.apache.kafka.clients.GroupRebalanceConfig;
-import org.apache.kafka.clients.NetworkClient;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.internals.events.ApplicationEvent;
 import org.apache.kafka.clients.consumer.internals.events.ApplicationEventProcessor;
-import org.apache.kafka.clients.consumer.internals.events.BackgroundEvent;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.errors.WakeupException;
-import org.apache.kafka.common.metrics.Metrics;
-import org.apache.kafka.common.metrics.Sensor;
-import org.apache.kafka.common.utils.KafkaThread;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.slf4j.Logger;
 
+import java.io.Closeable;
 import java.util.LinkedList;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.BlockingQueue;
-
-import static org.apache.kafka.clients.consumer.internals.Utils.CONSUMER_MAX_INFLIGHT_REQUESTS_PER_CONNECTION;
-import static org.apache.kafka.clients.consumer.internals.Utils.CONSUMER_METRIC_GROUP_PREFIX;
-import static org.apache.kafka.clients.consumer.internals.Utils.getConfiguredIsolationLevel;
+import java.util.function.Supplier;
 
 /**
  * Background thread runnable that consumes {@code ApplicationEvent} and
@@ -51,152 +40,46 @@ import static org.apache.kafka.clients.consumer.internals.Utils.getConfiguredIso
  * It holds a reference to the {@link SubscriptionState}, which is
  * initialized by the polling thread.
  */
-public class DefaultBackgroundThread extends KafkaThread {
+public class DefaultBackgroundThread<K, V> implements Runnable, Closeable {
 
     private static final long MAX_POLL_TIMEOUT_MS = 5000;
-    private static final String BACKGROUND_THREAD_NAME = "consumer_background_thread";
     private final Time time;
     private final Logger log;
     private final BlockingQueue<ApplicationEvent> applicationEventQueue;
-    private final BlockingQueue<BackgroundEvent> backgroundEventQueue;
-    private final ConsumerMetadata metadata;
-    private final SubscriptionState subscriptionState;
-    private final ConsumerConfig config;
-    // empty if groupId is null
-    private final ApplicationEventProcessor applicationEventProcessor;
-    private final NetworkClientDelegate networkClientDelegate;
-    private final ErrorEventHandler errorEventHandler;
-    private final GroupState groupState;
+    private final Supplier<ApplicationEventProcessor> applicationEventProcessorSupplier;
+    private final Supplier<NetworkClientDelegate> networkClientDelegateSupplier;
+    private final Supplier<RequestManagers> requestManagersSupplier;
     private volatile boolean running;
-    private volatile boolean closed;
+    private final IdempotentCloser closer = new IdempotentCloser();
 
-    private final RequestManagers requestManagers;
+    private ApplicationEventProcessor applicationEventProcessor;
+    private NetworkClientDelegate networkClientDelegate;
+    private RequestManagers requestManagers;
 
-    // Visible for testing
-    @SuppressWarnings("checkstyle:parameternumber")
-    DefaultBackgroundThread(final Time time,
-                            final ConsumerConfig config,
-                            final LogContext logContext,
-                            final BlockingQueue<ApplicationEvent> applicationEventQueue,
-                            final BlockingQueue<BackgroundEvent> backgroundEventQueue,
-                            final ConsumerMetadata metadata,
-                            final NetworkClientDelegate networkClient,
-                            final SubscriptionState subscriptionState,
-                            final GroupState groupState,
-                            final ErrorEventHandler errorEventHandler,
-                            final ApplicationEventProcessor processor,
-                            final CoordinatorRequestManager coordinatorManager,
-                            final CommitRequestManager commitRequestManager,
-                            final ListOffsetsRequestManager listOffsetsRequestManager,
-                            final TopicMetadataRequestManager topicMetadataRequestManager) {
-        super(BACKGROUND_THREAD_NAME, true);
+    public DefaultBackgroundThread(Time time,
+                                   LogContext logContext,
+                                   BlockingQueue<ApplicationEvent> applicationEventQueue,
+                                   Supplier<ApplicationEventProcessor> applicationEventProcessorSupplier,
+                                   Supplier<NetworkClientDelegate> networkClientDelegateSupplier,
+                                   Supplier<RequestManagers> requestManagersSupplier) {
         this.time = time;
-        this.log = logContext.logger(getClass());
+        this.log = logContext.logger(DefaultBackgroundThread.class);
         this.applicationEventQueue = applicationEventQueue;
-        this.backgroundEventQueue = backgroundEventQueue;
-        this.applicationEventProcessor = processor;
-        this.config = config;
-        this.metadata = metadata;
-        this.networkClientDelegate = networkClient;
-        this.subscriptionState = subscriptionState;
-        this.errorEventHandler = errorEventHandler;
-        this.groupState = groupState;
-
-        this.requestManagers = new RequestManagers(
-                listOffsetsRequestManager,
-                topicMetadataRequestManager,
-                Optional.ofNullable(coordinatorManager),
-                Optional.ofNullable(commitRequestManager));
-    }
-
-    public DefaultBackgroundThread(final Time time,
-                                   final ConsumerConfig config,
-                                   final LogContext logContext,
-                                   final BlockingQueue<ApplicationEvent> applicationEventQueue,
-                                   final BlockingQueue<BackgroundEvent> backgroundEventQueue,
-                                   final ConsumerMetadata metadata,
-                                   final ApiVersions apiVersions,
-                                   final Metrics metrics,
-                                   final Sensor fetcherThrottleTimeSensor,
-                                   final SubscriptionState subscriptions,
-                                   final GroupRebalanceConfig rebalanceConfig) {
-        super(BACKGROUND_THREAD_NAME, true);
-        try {
-            this.time = time;
-            this.log = logContext.logger(getClass());
-            this.applicationEventQueue = applicationEventQueue;
-            this.backgroundEventQueue = backgroundEventQueue;
-            this.config = config;
-            this.subscriptionState = subscriptions;
-            this.metadata = metadata;
-
-            final NetworkClient networkClient = ClientUtils.createNetworkClient(config,
-                metrics,
-                CONSUMER_METRIC_GROUP_PREFIX,
-                logContext,
-                apiVersions,
-                time,
-                CONSUMER_MAX_INFLIGHT_REQUESTS_PER_CONNECTION,
-                metadata,
-                fetcherThrottleTimeSensor);
-
-            this.networkClientDelegate = new NetworkClientDelegate(this.time, this.config, logContext, networkClient);
-            this.errorEventHandler = new ErrorEventHandler(this.backgroundEventQueue);
-            this.groupState = new GroupState(rebalanceConfig);
-            long retryBackoffMs = config.getLong(ConsumerConfig.RETRY_BACKOFF_MS_CONFIG);
-
-            ListOffsetsRequestManager offsetsRequestManager =
-                new ListOffsetsRequestManager(
-                    subscriptionState,
-                    metadata,
-                    getConfiguredIsolationLevel(config),
-                    time,
-                    apiVersions,
-                    logContext);
-            CoordinatorRequestManager coordinatorRequestManager = null;
-            CommitRequestManager commitRequestManager = null;
-            TopicMetadataRequestManager topicMetadataRequestManger = new TopicMetadataRequestManager(
-                logContext,
-                config);
-
-            if (groupState.groupId != null) {
-                coordinatorRequestManager = new CoordinatorRequestManager(this.time,
-                    logContext,
-                    retryBackoffMs, // TODO: let's pass in the config directly
-                    this.errorEventHandler,
-                    groupState.groupId);
-                commitRequestManager = new CommitRequestManager(this.time,
-                    logContext,
-                    subscriptions,
-                    config,
-                    coordinatorRequestManager,
-                    groupState);
-            }
-
-            this.requestManagers = new RequestManagers(
-                offsetsRequestManager,
-                topicMetadataRequestManger,
-                Optional.ofNullable(coordinatorRequestManager),
-                Optional.ofNullable(commitRequestManager));
-            this.applicationEventProcessor = new ApplicationEventProcessor(
-                backgroundEventQueue,
-                requestManagers,
-                metadata);
-        } catch (final Exception e) {
-            close();
-            throw new KafkaException("Failed to construct background processor", e.getCause());
-        }
+        this.applicationEventProcessorSupplier = applicationEventProcessorSupplier;
+        this.networkClientDelegateSupplier = networkClientDelegateSupplier;
+        this.requestManagersSupplier = requestManagersSupplier;
     }
 
     @Override
     public void run() {
-        if (closed)
-            throw new IllegalStateException("Background consumer thread is closed");
-
+        closer.maybeThrowIllegalStateException("Consumer background thread is already closed");
         running = true;
 
         try {
             log.debug("Background thread started");
+
+            // Wait until we're securely in the background thread to initialize these objects...
+            initializeResources();
 
             while (running) {
                 try {
@@ -213,6 +96,12 @@ public class DefaultBackgroundThread extends KafkaThread {
             close();
             log.debug("Background thread closed");
         }
+    }
+
+    void initializeResources() {
+        applicationEventProcessor = applicationEventProcessorSupplier.get();
+        networkClientDelegate = networkClientDelegateSupplier.get();
+        requestManagers = requestManagersSupplier.get();
     }
 
     /**
@@ -255,17 +144,21 @@ public class DefaultBackgroundThread extends KafkaThread {
     }
 
     public void wakeup() {
-        networkClientDelegate.wakeup();
+        if (networkClientDelegate != null)
+            networkClientDelegate.wakeup();
     }
 
+    @Override
     public void close() {
-        if (closed)
-            return;
-
-        closed = true;
-        running = false;
-        wakeup();
-        Utils.closeQuietly(networkClientDelegate, "network client utils");
-        Utils.closeQuietly(metadata, "consumer metadata client");
+        closer.close(() -> {
+            log.debug("Closing the consumer background thread");
+            running = false;
+            wakeup();
+            Utils.closeQuietly(requestManagers, "Request managers client");
+            Utils.closeQuietly(networkClientDelegate, "network client utils");
+            log.debug("Closed the consumer background thread");
+        }, () -> {
+            log.warn("The consumer background thread was previously closed");
+        });
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThread.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThread.java
@@ -40,7 +40,7 @@ import java.util.function.Supplier;
  * It holds a reference to the {@link SubscriptionState}, which is
  * initialized by the polling thread.
  */
-public class DefaultBackgroundThread<K, V> implements Runnable, Closeable {
+public class DefaultBackgroundThread implements Runnable, Closeable {
 
     private static final long MAX_POLL_TIMEOUT_MS = 5000;
     private final Time time;
@@ -157,8 +157,6 @@ public class DefaultBackgroundThread<K, V> implements Runnable, Closeable {
             Utils.closeQuietly(requestManagers, "Request managers client");
             Utils.closeQuietly(networkClientDelegate, "network client utils");
             log.debug("Closed the consumer background thread");
-        }, () -> {
-            log.warn("The consumer background thread was previously closed");
-        });
+        }, () -> log.warn("The consumer background thread was previously closed"));
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThread.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThread.java
@@ -66,7 +66,7 @@ public class DefaultBackgroundThread extends KafkaThread implements Closeable {
                                    Supplier<RequestManagers> requestManagersSupplier) {
         super(BACKGROUND_THREAD_NAME, true);
         this.time = time;
-        this.log = logContext.logger(DefaultBackgroundThread.class);
+        this.log = logContext.logger(getClass());
         this.applicationEventQueue = applicationEventQueue;
         this.applicationEventProcessorSupplier = applicationEventProcessorSupplier;
         this.networkClientDelegateSupplier = networkClientDelegateSupplier;

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultEventHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultEventHandler.java
@@ -46,7 +46,7 @@ public class DefaultEventHandler<K, V> implements EventHandler {
     private final Time time;
     private final BlockingQueue<ApplicationEvent> applicationEventQueue;
     private final BlockingQueue<BackgroundEvent> backgroundEventQueue;
-    private final DefaultBackgroundThread<K, V> backgroundThread;
+    private final DefaultBackgroundThread backgroundThread;
     private final KafkaThread ioThread;
     private final IdempotentCloser closer = new IdempotentCloser();
 
@@ -62,7 +62,7 @@ public class DefaultEventHandler<K, V> implements EventHandler {
         this.time = time;
         this.applicationEventQueue = applicationEventQueue;
         this.backgroundEventQueue = backgroundEventQueue;
-        this.backgroundThread = new DefaultBackgroundThread<>(time,
+        this.backgroundThread = new DefaultBackgroundThread(time,
                 logContext,
                 applicationEventQueue,
                 applicationEventProcessorSupplier,
@@ -126,9 +126,7 @@ public class DefaultEventHandler<K, V> implements EventHandler {
                         throw new KafkaException(e);
                     }
                 },
-                () -> {
-                    log.info("The default consumer event handler was already closed");
-                });
+                () -> log.info("The default consumer event handler was already closed"));
 
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultEventHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultEventHandler.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.clients.consumer.internals;
 
-import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.internals.events.ApplicationEvent;
 import org.apache.kafka.clients.consumer.internals.events.ApplicationEventProcessor;
 import org.apache.kafka.clients.consumer.internals.events.BackgroundEvent;
@@ -33,13 +32,11 @@ import java.util.Optional;
 import java.util.concurrent.BlockingQueue;
 import java.util.function.Supplier;
 
-import static org.apache.kafka.clients.consumer.internals.PrototypeAsyncConsumer.NETWORK_THREAD_PREFIX;
-
 /**
  * An {@link EventHandler} that uses a single background thread to consume {@link ApplicationEvent} and produce
  * {@link BackgroundEvent} from the {@link DefaultBackgroundThread}.
  */
-public class DefaultEventHandler<K, V> implements EventHandler {
+public class DefaultEventHandler implements EventHandler {
 
     private final Logger log;
     private final Time time;
@@ -49,7 +46,6 @@ public class DefaultEventHandler<K, V> implements EventHandler {
     private final IdempotentCloser closer = new IdempotentCloser();
 
     public DefaultEventHandler(final Time time,
-                               final ConsumerConfig config,
                                final LogContext logContext,
                                final BlockingQueue<ApplicationEvent> applicationEventQueue,
                                final BlockingQueue<BackgroundEvent> backgroundEventQueue,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultEventHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultEventHandler.java
@@ -16,107 +16,61 @@
  */
 package org.apache.kafka.clients.consumer.internals;
 
-import org.apache.kafka.clients.ApiVersions;
-import org.apache.kafka.clients.ClientUtils;
-import org.apache.kafka.clients.GroupRebalanceConfig;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.internals.events.ApplicationEvent;
+import org.apache.kafka.clients.consumer.internals.events.ApplicationEventProcessor;
 import org.apache.kafka.clients.consumer.internals.events.BackgroundEvent;
 import org.apache.kafka.clients.consumer.internals.events.CompletableApplicationEvent;
 import org.apache.kafka.clients.consumer.internals.events.EventHandler;
-import org.apache.kafka.common.internals.ClusterResourceListeners;
-import org.apache.kafka.common.metrics.Metrics;
-import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.utils.KafkaThread;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
+import org.slf4j.Logger;
 
-import java.net.InetSocketAddress;
 import java.time.Duration;
-import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedBlockingQueue;
+import java.util.function.Supplier;
+
+import static org.apache.kafka.clients.consumer.internals.PrototypeAsyncConsumer.NETWORK_THREAD_PREFIX;
 
 /**
- * An {@code EventHandler} that uses a single background thread to consume {@code ApplicationEvent} and produce
- * {@code BackgroundEvent} from the {@link DefaultBackgroundThread}.
+ * An {@link EventHandler} that uses a single background thread to consume {@link ApplicationEvent} and produce
+ * {@link BackgroundEvent} from the {@link DefaultBackgroundThread}.
  */
-public class DefaultEventHandler implements EventHandler {
+public class DefaultEventHandler<K, V> implements EventHandler {
 
+    private final Logger log;
     private final Time time;
     private final BlockingQueue<ApplicationEvent> applicationEventQueue;
     private final BlockingQueue<BackgroundEvent> backgroundEventQueue;
-    private final DefaultBackgroundThread backgroundThread;
-
-    public DefaultEventHandler(final ConsumerConfig config,
-                               final GroupRebalanceConfig groupRebalanceConfig,
-                               final LogContext logContext,
-                               final SubscriptionState subscriptions,
-                               final ApiVersions apiVersions,
-                               final Metrics metrics,
-                               final ClusterResourceListeners clusterResourceListeners,
-                               final Sensor fetcherThrottleTimeSensor) {
-        this(Time.SYSTEM,
-                config,
-                logContext,
-                new LinkedBlockingQueue<>(),
-                new LinkedBlockingQueue<>(),
-                subscriptions,
-                groupRebalanceConfig,
-                apiVersions,
-                metrics,
-                clusterResourceListeners,
-                fetcherThrottleTimeSensor);
-    }
+    private final DefaultBackgroundThread<K, V> backgroundThread;
+    private final KafkaThread ioThread;
+    private final IdempotentCloser closer = new IdempotentCloser();
 
     public DefaultEventHandler(final Time time,
                                final ConsumerConfig config,
                                final LogContext logContext,
                                final BlockingQueue<ApplicationEvent> applicationEventQueue,
                                final BlockingQueue<BackgroundEvent> backgroundEventQueue,
-                               final SubscriptionState subscriptions,
-                               final GroupRebalanceConfig groupRebalanceConfig,
-                               final ApiVersions apiVersions,
-                               final Metrics metrics,
-                               final ClusterResourceListeners clusterResourceListeners,
-                               final Sensor fetcherThrottleTimeSensor) {
+                               final Supplier<ApplicationEventProcessor> applicationEventProcessorSupplier,
+                               final Supplier<NetworkClientDelegate> networkClientDelegateSupplier,
+                               final Supplier<RequestManagers> requestManagersSupplier) {
+        this.log = logContext.logger(DefaultEventHandler.class);
         this.time = time;
         this.applicationEventQueue = applicationEventQueue;
         this.backgroundEventQueue = backgroundEventQueue;
-
-        // Bootstrap a metadata object with the bootstrap server IP address, which will be used once for the
-        // subsequent metadata refresh once the background thread has started up.
-        final ConsumerMetadata metadata = new ConsumerMetadata(config,
-                subscriptions,
+        this.backgroundThread = new DefaultBackgroundThread<>(time,
                 logContext,
-                clusterResourceListeners);
-        final List<InetSocketAddress> addresses = ClientUtils.parseAndValidateAddresses(config);
-        metadata.bootstrap(addresses);
-
-        this.backgroundThread = new DefaultBackgroundThread(time,
-                config,
-                logContext,
-                this.applicationEventQueue,
-                this.backgroundEventQueue,
-                metadata,
-                apiVersions,
-                metrics,
-                fetcherThrottleTimeSensor,
-                subscriptions,
-                groupRebalanceConfig);
-        this.backgroundThread.start();
-    }
-
-    // VisibleForTesting
-    DefaultEventHandler(final Time time,
-                        final DefaultBackgroundThread backgroundThread,
-                        final BlockingQueue<ApplicationEvent> applicationEventQueue,
-                        final BlockingQueue<BackgroundEvent> backgroundEventQueue) {
-        this.time = time;
-        this.backgroundThread = backgroundThread;
-        this.applicationEventQueue = applicationEventQueue;
-        this.backgroundEventQueue = backgroundEventQueue;
-        backgroundThread.start();
+                applicationEventQueue,
+                applicationEventProcessorSupplier,
+                networkClientDelegateSupplier,
+                requestManagersSupplier);
+        String ioThreadName = NETWORK_THREAD_PREFIX + " | " + config.getString(ConsumerConfig.CLIENT_ID_CONFIG);
+        this.ioThread = new KafkaThread(ioThreadName, this.backgroundThread, true);
+        this.ioThread.start();
     }
 
     @Override
@@ -131,21 +85,50 @@ public class DefaultEventHandler implements EventHandler {
 
     @Override
     public boolean add(final ApplicationEvent event) {
+        Objects.requireNonNull(event, "ApplicationEvent provided to add must be non-null");
         backgroundThread.wakeup();
         return applicationEventQueue.add(event);
     }
 
     @Override
-    public <T> T addAndGet(CompletableApplicationEvent<T> event, Duration timeout) {
+    public <T> T addAndGet(final CompletableApplicationEvent<T> event, final Duration timeout) {
+        Objects.requireNonNull(event, "CompletableApplicationEvent provided to addAndGet must be non-null");
+        Objects.requireNonNull(timeout, "Duration provided to addAndGet must be non-null");
         add(event);
         return event.get(time.timer(timeout));
     }
 
-    public void close() {
-        try {
-            backgroundThread.close();
-        } catch (final Exception e) {
-            throw new RuntimeException(e);
-        }
+    public void close(final Duration timeout) {
+        Objects.requireNonNull(timeout, "Duration provided to close must be non-null");
+
+        closer.close(
+                () ->  {
+                    log.info("Closing the default consumer event handler");
+
+                    try {
+                        long timeoutMs = timeout.toMillis();
+
+                        if (timeoutMs < 0)
+                            throw new IllegalArgumentException("The timeout cannot be negative.");
+
+                        backgroundThread.close();
+
+                        if (this.ioThread != null) {
+                            try {
+                                this.ioThread.join(timeoutMs);
+                            } catch (InterruptedException t) {
+                                log.error("Interrupted while joining ioThread", t);
+                            }
+                        }
+
+                        log.info("The default consumer event handler was closed");
+                    } catch (final Exception e) {
+                        throw new KafkaException(e);
+                    }
+                },
+                () -> {
+                    log.info("The default consumer event handler was already closed");
+                });
+
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/NetworkClientDelegate.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/NetworkClientDelegate.java
@@ -287,13 +287,13 @@ public class NetworkClientDelegate implements NodeStatusDetector, AutoCloseable 
      * Creates a {@link Supplier} for deferred creation during invocation by
      * {@link org.apache.kafka.clients.consumer.internals.DefaultBackgroundThread}.
      */
-    public static Supplier<NetworkClientDelegate> creator(final Time time,
-                                                          final LogContext logContext,
-                                                          final ConsumerMetadata metadata,
-                                                          final ConsumerConfig config,
-                                                          final ApiVersions apiVersions,
-                                                          final Metrics metrics,
-                                                          final FetchMetricsManager fetchMetricsManager) {
+    public static Supplier<NetworkClientDelegate> supplier(final Time time,
+                                                           final LogContext logContext,
+                                                           final ConsumerMetadata metadata,
+                                                           final ConsumerConfig config,
+                                                           final ApiVersions apiVersions,
+                                                           final Metrics metrics,
+                                                           final FetchMetricsManager fetchMetricsManager) {
         return new CachedSupplier<NetworkClientDelegate>() {
             @Override
             protected NetworkClientDelegate create() {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/NetworkClientDelegate.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/NetworkClientDelegate.java
@@ -16,8 +16,10 @@
  */
 package org.apache.kafka.clients.consumer.internals;
 
+import org.apache.kafka.clients.ApiVersions;
 import org.apache.kafka.clients.ClientRequest;
 import org.apache.kafka.clients.ClientResponse;
+import org.apache.kafka.clients.ClientUtils;
 import org.apache.kafka.clients.KafkaClient;
 import org.apache.kafka.clients.NetworkClientUtils;
 import org.apache.kafka.clients.RequestCompletionHandler;
@@ -26,6 +28,7 @@ import org.apache.kafka.common.Node;
 import org.apache.kafka.common.errors.AuthenticationException;
 import org.apache.kafka.common.errors.DisconnectException;
 import org.apache.kafka.common.errors.TimeoutException;
+import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.requests.AbstractRequest;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
@@ -42,6 +45,10 @@ import java.util.Optional;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
+import java.util.function.Supplier;
+
+import static org.apache.kafka.clients.consumer.internals.Utils.CONSUMER_MAX_INFLIGHT_REQUESTS_PER_CONNECTION;
+import static org.apache.kafka.clients.consumer.internals.Utils.CONSUMER_METRIC_GROUP_PREFIX;
 
 /**
  * A wrapper around the {@link org.apache.kafka.clients.NetworkClient} to handle network poll and send operations.
@@ -274,5 +281,33 @@ public class NetworkClientDelegate implements NodeStatusDetector, AutoCloseable 
                 future.complete(response);
             }
         }
+    }
+
+    /**
+     * Creates a {@link Supplier} for deferred creation during invocation by
+     * {@link org.apache.kafka.clients.consumer.internals.DefaultBackgroundThread}.
+     */
+    public static Supplier<NetworkClientDelegate> creator(final Time time,
+                                                          final LogContext logContext,
+                                                          final ConsumerMetadata metadata,
+                                                          final ConsumerConfig config,
+                                                          final ApiVersions apiVersions,
+                                                          final Metrics metrics,
+                                                          final FetchMetricsManager fetchMetricsManager) {
+        return new CachedSupplier<NetworkClientDelegate>() {
+            @Override
+            protected NetworkClientDelegate create() {
+                KafkaClient client = ClientUtils.createNetworkClient(config,
+                        metrics,
+                        CONSUMER_METRIC_GROUP_PREFIX,
+                        logContext,
+                        apiVersions,
+                        time,
+                        CONSUMER_MAX_INFLIGHT_REQUESTS_PER_CONNECTION,
+                        metadata,
+                        fetchMetricsManager.throttleTimeSensor());
+                return new NetworkClientDelegate(time, config, logContext, client);
+            }
+        };
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumer.java
@@ -105,7 +105,6 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
     private final Time time;
     private final Optional<String> groupId;
     private final Logger log;
-
     private final SubscriptionState subscriptions;
     private final long defaultApiTimeoutMs;
 
@@ -191,12 +190,12 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
                                   SubscriptionState subscriptions,
                                   long defaultApiTimeoutMs) {
         this.logContext = logContext;
-        this.log = logContext.logger(PrototypeAsyncConsumer.class);
-        this.time = time;
-        this.eventHandler = eventHandler;
-        this.groupId = groupId;
+        this.log = logContext.logger(getClass());
         this.subscriptions = subscriptions;
+        this.time = time;
+        this.groupId = groupId;
         this.defaultApiTimeoutMs = defaultApiTimeoutMs;
+        this.eventHandler = eventHandler;
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumer.java
@@ -51,7 +51,6 @@ import org.apache.kafka.common.requests.ListOffsetsRequest;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
-import org.apache.kafka.common.utils.Timer;
 import org.slf4j.Logger;
 
 import java.net.InetSocketAddress;
@@ -66,7 +65,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Properties;
-import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumer.java
@@ -98,14 +98,11 @@ import static org.apache.kafka.common.utils.Utils.propsToMap;
  * for detail implementation.
  */
 public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
-
     static final long DEFAULT_CLOSE_TIMEOUT_MS = 30 * 1000;
-    static final String NETWORK_THREAD_PREFIX = "kafka-consumer-network-thread";
 
     private final LogContext logContext;
-    private final Time time;
-    private final ConsumerMetadata metadata;
     private final EventHandler eventHandler;
+    private final Time time;
     private final Optional<String> groupId;
     private final Logger log;
 
@@ -149,7 +146,7 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
         ClusterResourceListeners clusterResourceListeners = ClientUtils.configureClusterResourceListeners(metrics.reporters(),
                 interceptorList,
                 Arrays.asList(deserializers.keyDeserializer, deserializers.valueDeserializer));
-        this.metadata = new ConsumerMetadata(config, subscriptions, logContext, clusterResourceListeners);
+        ConsumerMetadata metadata = new ConsumerMetadata(config, subscriptions, logContext, clusterResourceListeners);
         // Bootstrap the metadata with the bootstrap server IP address, which will be used once for the subsequent
         // metadata refresh once the background thread has started up.
         final List<InetSocketAddress> addresses = ClientUtils.parseAndValidateAddresses(config);
@@ -178,8 +175,7 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
                 metadata,
                 backgroundEventQueue,
                 requestManagersSupplier);
-        this.eventHandler = new DefaultEventHandler<>(time,
-                config,
+        this.eventHandler = new DefaultEventHandler(time,
                 logContext,
                 applicationEventQueue,
                 backgroundEventQueue,
@@ -190,7 +186,6 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
 
     public PrototypeAsyncConsumer(LogContext logContext,
                                   Time time,
-                                  ConsumerMetadata metadata,
                                   EventHandler eventHandler,
                                   Optional<String> groupId,
                                   SubscriptionState subscriptions,
@@ -198,7 +193,6 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
         this.logContext = logContext;
         this.log = logContext.logger(PrototypeAsyncConsumer.class);
         this.time = time;
-        this.metadata = metadata;
         this.eventHandler = eventHandler;
         this.groupId = groupId;
         this.subscriptions = subscriptions;

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestManagers.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestManagers.java
@@ -48,7 +48,6 @@ public class RequestManagers implements Closeable {
     public final Optional<CommitRequestManager> commitRequestManager;
     public final ListOffsetsRequestManager listOffsetsRequestManager;
     public final TopicMetadataRequestManager topicMetadataRequestManager;
-
     private final List<Optional<? extends RequestManager>> entries;
     private final IdempotentCloser closer = new IdempotentCloser();
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestManagers.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestManagers.java
@@ -16,30 +16,48 @@
  */
 package org.apache.kafka.clients.consumer.internals;
 
+import org.apache.kafka.clients.ApiVersions;
+import org.apache.kafka.clients.GroupRebalanceConfig;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.internals.events.BackgroundEvent;
+import org.apache.kafka.common.IsolationLevel;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.Time;
+import org.slf4j.Logger;
+
+import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.BlockingQueue;
+import java.util.function.Supplier;
 
 import static java.util.Objects.requireNonNull;
+import static org.apache.kafka.clients.consumer.internals.Utils.getConfiguredIsolationLevel;
 
 /**
  * {@code RequestManagers} provides a means to pass around the set of {@link RequestManager} instances in the system.
  * This allows callers to both use the specific {@link RequestManager} instance, or to iterate over the list via
  * the {@link #entries()} method.
  */
-public class RequestManagers {
+public class RequestManagers implements Closeable {
 
+    private final Logger log;
     public final Optional<CoordinatorRequestManager> coordinatorRequestManager;
     public final Optional<CommitRequestManager> commitRequestManager;
     public final ListOffsetsRequestManager listOffsetsRequestManager;
     public final TopicMetadataRequestManager topicMetadataRequestManager;
-    private final List<Optional<? extends RequestManager>> entries;
 
-    public RequestManagers(ListOffsetsRequestManager listOffsetsRequestManager,
+    private final List<Optional<? extends RequestManager>> entries;
+    private final IdempotentCloser closer = new IdempotentCloser();
+
+    public RequestManagers(LogContext logContext,
+                           ListOffsetsRequestManager listOffsetsRequestManager,
                            TopicMetadataRequestManager topicMetadataRequestManager,
                            Optional<CoordinatorRequestManager> coordinatorRequestManager,
                            Optional<CommitRequestManager> commitRequestManager) {
+        this.log = logContext.logger(RequestManagers.class);
         this.listOffsetsRequestManager = requireNonNull(listOffsetsRequestManager, "ListOffsetsRequestManager cannot be null");
         this.coordinatorRequestManager = coordinatorRequestManager;
         this.commitRequestManager = commitRequestManager;
@@ -55,5 +73,79 @@ public class RequestManagers {
 
     public List<Optional<? extends RequestManager>> entries() {
         return entries;
+    }
+
+    @Override
+    public void close() {
+        closer.close(
+                () -> {
+                    log.debug("Closing RequestManagers");
+
+                    entries.forEach(rm -> {
+                        rm.ifPresent(requestManager -> {
+                            try {
+                                requestManager.close();
+                            } catch (Throwable t) {
+                                log.debug("Error closing request manager {}", requestManager.getClass().getSimpleName(), t);
+                            }
+                        });
+                    });
+                    log.debug("RequestManagers has been closed");
+                },
+                () -> {
+                    log.debug("RequestManagers was already closed");
+                });
+
+    }
+
+    /**
+     * Creates a {@link Supplier} for deferred creation during invocation by
+     * {@link org.apache.kafka.clients.consumer.internals.DefaultBackgroundThread}.
+     */
+    public static Supplier<RequestManagers> creator(final Time time,
+                                                                 final LogContext logContext,
+                                                                 final BlockingQueue<BackgroundEvent> backgroundEventQueue,
+                                                                 final ConsumerMetadata metadata,
+                                                                 final SubscriptionState subscriptions,
+                                                                 final ConsumerConfig config,
+                                                                 final GroupRebalanceConfig groupRebalanceConfig,
+                                                                 final ApiVersions apiVersions,
+                                                                 final Supplier<NetworkClientDelegate> networkClientDelegateSupplier) {
+        return new CachedSupplier<RequestManagers>() {
+            @Override
+            protected RequestManagers create() {
+                final ErrorEventHandler errorEventHandler = new ErrorEventHandler(backgroundEventQueue);
+                final IsolationLevel isolationLevel = getConfiguredIsolationLevel(config);
+                final ListOffsetsRequestManager listOffsets = new ListOffsetsRequestManager(subscriptions,
+                        metadata,
+                        isolationLevel,
+                        time,
+                        apiVersions,
+                        logContext);
+                final TopicMetadataRequestManager topicMetadata = new TopicMetadataRequestManager(logContext, config);
+                final CoordinatorRequestManager coordinator;
+                final CommitRequestManager commit;
+
+                if (groupRebalanceConfig != null && groupRebalanceConfig.groupId != null) {
+                    final long retryBackoffMs = config.getLong(ConsumerConfig.RETRY_BACKOFF_MS_CONFIG);
+                    final GroupState groupState = new GroupState(groupRebalanceConfig);
+                    coordinator = new CoordinatorRequestManager(time,
+                            logContext,
+                            retryBackoffMs,
+                            errorEventHandler,
+                            groupState.groupId);
+                    commit = new CommitRequestManager(time, logContext, subscriptions, config, coordinator, groupState);
+                } else {
+                    coordinator = null;
+                    commit = null;
+                }
+
+                return new RequestManagers(logContext,
+                        listOffsets,
+                        topicMetadata,
+                        Optional.ofNullable(coordinator),
+                        Optional.ofNullable(commit));
+            }
+        };
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Utils.java
@@ -43,7 +43,6 @@ import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.MetricsContext;
 import org.apache.kafka.common.metrics.MetricsReporter;
 import org.apache.kafka.common.metrics.Sensor;
-import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 
@@ -92,7 +91,7 @@ public final class Utils {
 
     public static LogContext createLogContext(ConsumerConfig config, GroupRebalanceConfig groupRebalanceConfig) {
         Optional<String> groupId = Optional.ofNullable(groupRebalanceConfig.groupId);
-        String clientId = config.getString(CommonClientConfigs.CLIENT_ID_CONFIG);
+        String clientId = config.getString(ConsumerConfig.CLIENT_ID_CONFIG);
 
         // If group.instance.id is set, we will append it to the log context.
         if (groupRebalanceConfig.groupInstanceId.isPresent()) {
@@ -139,10 +138,9 @@ public final class Utils {
         return new FetchConfig<>(config, deserializers, isolationLevel);
     }
 
-    public static FetchConfig<String, String> createFetchConfig(ConsumerConfig config) {
-        Deserializers<String, String> deserializers = new Deserializers<>(new StringDeserializer(), new StringDeserializer());
-        IsolationLevel isolationLevel = getConfiguredIsolationLevel(config);
-        return new FetchConfig<>(config, deserializers, isolationLevel);
+    public static <K, V> FetchConfig<K, V> createFetchConfig(ConsumerConfig config) {
+        Deserializers<K, V> deserializers = new Deserializers<>(config);
+        return createFetchConfig(config, deserializers);
     }
 
     @SuppressWarnings("unchecked")

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
@@ -17,12 +17,15 @@
 package org.apache.kafka.clients.consumer.internals.events;
 
 import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
+import org.apache.kafka.clients.consumer.internals.CachedSupplier;
 import org.apache.kafka.clients.consumer.internals.CommitRequestManager;
 import org.apache.kafka.clients.consumer.internals.ConsumerMetadata;
 import org.apache.kafka.clients.consumer.internals.RequestManagers;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.utils.LogContext;
+import org.slf4j.Logger;
 
 import java.util.List;
 import java.util.Map;
@@ -30,10 +33,13 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
 
 public class ApplicationEventProcessor {
 
     private final BlockingQueue<BackgroundEvent> backgroundEventQueue;
+
+    private final Logger log;
 
     private final ConsumerMetadata metadata;
 
@@ -41,15 +47,23 @@ public class ApplicationEventProcessor {
 
     public ApplicationEventProcessor(final BlockingQueue<BackgroundEvent> backgroundEventQueue,
                                      final RequestManagers requestManagers,
-                                     final ConsumerMetadata metadata) {
+                                     final ConsumerMetadata metadata,
+                                     final LogContext logContext) {
+        this.log = logContext.logger(ApplicationEventProcessor.class);
         this.backgroundEventQueue = backgroundEventQueue;
         this.requestManagers = requestManagers;
         this.metadata = metadata;
     }
 
     public boolean process(final ApplicationEvent event) {
-        Objects.requireNonNull(event);
-        switch (event.type) {
+        Objects.requireNonNull(event, "Attempt to process null ApplicationEvent");
+        Objects.requireNonNull(event.type(), "Attempt to process ApplicationEvent with null type: " + event);
+
+        log.debug("Processing event {}", event);
+
+        // Make sure to use the event's type() method, not the type variable directly. This causes problems when
+        // unit tests mock the EventType.
+        switch (event.type()) {
             case NOOP:
                 return process((NoopApplicationEvent) event);
             case COMMIT:
@@ -71,7 +85,7 @@ public class ApplicationEventProcessor {
     }
 
     /**
-     * Processes {@link NoopApplicationEvent} and equeue a
+     * Processes {@link NoopApplicationEvent} and enqueue a
      * {@link NoopBackgroundEvent}. This is intentionally left here for
      * demonstration purpose.
      *
@@ -107,7 +121,7 @@ public class ApplicationEventProcessor {
 
     private boolean process(final OffsetFetchApplicationEvent event) {
         if (!requestManagers.commitRequestManager.isPresent()) {
-            event.future.completeExceptionally(new KafkaException("Unable to fetch committed offset because the " +
+            event.future().completeExceptionally(new KafkaException("Unable to fetch committed offset because the " +
                     "CommittedRequestManager is not available. Check if group.id was set correctly"));
             return false;
         }
@@ -142,5 +156,22 @@ public class ApplicationEventProcessor {
                 this.requestManagers.topicMetadataRequestManager.requestTopicMetadata(Optional.of(event.topic()));
         event.chain(future);
         return true;
+    }
+
+    /**
+     * Creates a {@link Supplier} for deferred creation during invocation by
+     * {@link org.apache.kafka.clients.consumer.internals.DefaultBackgroundThread}.
+     */
+    public static Supplier<ApplicationEventProcessor> creator(final LogContext logContext,
+                                                              final ConsumerMetadata metadata,
+                                                              final BlockingQueue<BackgroundEvent> backgroundEventQueue,
+                                                              final Supplier<RequestManagers> requestManagersSupplier) {
+        return new CachedSupplier<ApplicationEventProcessor>() {
+            @Override
+            protected ApplicationEventProcessor create() {
+                RequestManagers requestManagers = requestManagersSupplier.get();
+                return new ApplicationEventProcessor(backgroundEventQueue, requestManagers, metadata, logContext);
+            }
+        };
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
@@ -162,10 +162,10 @@ public class ApplicationEventProcessor {
      * Creates a {@link Supplier} for deferred creation during invocation by
      * {@link org.apache.kafka.clients.consumer.internals.DefaultBackgroundThread}.
      */
-    public static Supplier<ApplicationEventProcessor> creator(final LogContext logContext,
-                                                              final ConsumerMetadata metadata,
-                                                              final BlockingQueue<BackgroundEvent> backgroundEventQueue,
-                                                              final Supplier<RequestManagers> requestManagersSupplier) {
+    public static Supplier<ApplicationEventProcessor> supplier(final LogContext logContext,
+                                                               final ConsumerMetadata metadata,
+                                                               final BlockingQueue<BackgroundEvent> backgroundEventQueue,
+                                                               final Supplier<RequestManagers> requestManagersSupplier) {
         return new CachedSupplier<ApplicationEventProcessor>() {
             @Override
             protected ApplicationEventProcessor create() {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/EventHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/EventHandler.java
@@ -80,4 +80,10 @@ public interface EventHandler extends Closeable {
      * @param <T>     Type of return value of the event
      */
     <T> T addAndGet(CompletableApplicationEvent<T> event, Duration timeout);
+
+    default void close() {
+        close(Duration.ofMillis(Long.MAX_VALUE));
+    }
+
+    void close(Duration timeout);
 }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerTestBuilder.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerTestBuilder.java
@@ -174,9 +174,8 @@ public class ConsumerTestBuilder implements Closeable {
         final EventHandler eventHandler;
 
         public DefaultEventHandlerTestBuilder() {
-            this.eventHandler = spy(new DefaultEventHandler<>(
+            this.eventHandler = spy(new DefaultEventHandler(
                     time,
-                    config,
                     logContext,
                     applicationEventQueue,
                     backgroundEventQueue,
@@ -198,7 +197,6 @@ public class ConsumerTestBuilder implements Closeable {
         public PrototypeAsyncConsumerTestBuilder(Optional<String> groupIdOpt) {
             this.consumer = spy(new PrototypeAsyncConsumer<>(logContext,
                     time,
-                    metadata,
                     eventHandler,
                     groupIdOpt,
                     subscriptions,

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerTestBuilder.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerTestBuilder.java
@@ -151,10 +151,10 @@ public class ConsumerTestBuilder implements Closeable {
 
     public static class DefaultBackgroundThreadTestBuilder extends ConsumerTestBuilder {
 
-        final DefaultBackgroundThread<String, String> backgroundThread;
+        final DefaultBackgroundThread backgroundThread;
 
         public DefaultBackgroundThreadTestBuilder() {
-            this.backgroundThread = new DefaultBackgroundThread<>(
+            this.backgroundThread = new DefaultBackgroundThread(
                     time,
                     logContext,
                     applicationEventQueue,
@@ -197,22 +197,13 @@ public class ConsumerTestBuilder implements Closeable {
         final PrototypeAsyncConsumer<String, String> consumer;
 
         public PrototypeAsyncConsumerTestBuilder(Optional<String> groupIdOpt) {
-            FetchCollector<String, String> fetchCollector = new FetchCollector<>(logContext,
-                    metadata,
-                    subscriptions,
-                    fetchConfig,
-                    metricsManager,
-                    time);
             this.consumer = spy(new PrototypeAsyncConsumer<>(logContext,
                     time,
                     metadata,
                     eventHandler,
                     groupIdOpt,
-                    new ConsumerInterceptors<>(Collections.emptyList()),
                     subscriptions,
-                    3000,
-                    new FetchBuffer<>(logContext),
-                    fetchCollector));
+                    3000));
         }
 
         @Override

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerTestBuilder.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerTestBuilder.java
@@ -1,0 +1,223 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer.internals;
+
+import org.apache.kafka.clients.ApiVersions;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.GroupRebalanceConfig;
+import org.apache.kafka.clients.KafkaClient;
+import org.apache.kafka.clients.MockClient;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.internals.events.ApplicationEvent;
+import org.apache.kafka.clients.consumer.internals.events.ApplicationEventProcessor;
+import org.apache.kafka.clients.consumer.internals.events.BackgroundEvent;
+import org.apache.kafka.clients.consumer.internals.events.EventHandler;
+import org.apache.kafka.common.IsolationLevel;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.internals.ClusterResourceListeners;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.common.utils.Time;
+
+import java.io.Closeable;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.function.Supplier;
+
+import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.clients.consumer.internals.Utils.createFetchConfig;
+import static org.apache.kafka.clients.consumer.internals.Utils.createFetchMetricsManager;
+import static org.apache.kafka.clients.consumer.internals.Utils.createMetrics;
+import static org.apache.kafka.clients.consumer.internals.Utils.createSubscriptionState;
+import static org.apache.kafka.clients.consumer.internals.Utils.getConfiguredIsolationLevel;
+import static org.mockito.Mockito.spy;
+
+public class ConsumerTestBuilder implements Closeable {
+
+    static final long RETRY_BACKOFF_MS = 80;
+    static final int REQUEST_TIMEOUT_MS = 500;
+
+    final LogContext logContext = new LogContext();
+    final Time time = new MockTime(1, 0, 0);
+    final BlockingQueue<ApplicationEvent> applicationEventQueue;
+    final LinkedBlockingQueue<BackgroundEvent> backgroundEventQueue;
+    final ConsumerConfig config;
+    final SubscriptionState subscriptions;
+    final ConsumerMetadata metadata;
+    final FetchConfig<String, String> fetchConfig;
+    final FetchMetricsManager metricsManager;
+    final NetworkClientDelegate networkClientDelegate;
+    final ListOffsetsRequestManager listOffsetsRequestManager;
+    final TopicMetadataRequestManager topicMetadataRequestManager;
+    final CoordinatorRequestManager coordinatorRequestManager;
+    final CommitRequestManager commitRequestManager;
+    final RequestManagers requestManagers;
+    final ApplicationEventProcessor applicationEventProcessor;
+    final Supplier<ApplicationEventProcessor> applicationEventProcessorSupplier;
+    final Supplier<NetworkClientDelegate> networkClientDelegateSupplier;
+    final Supplier<RequestManagers> requestManagersSupplier;
+
+    public ConsumerTestBuilder() {
+        this.applicationEventQueue = new LinkedBlockingQueue<>();
+        this.backgroundEventQueue = new LinkedBlockingQueue<>();
+        ErrorEventHandler errorEventHandler = new ErrorEventHandler(backgroundEventQueue);
+        GroupRebalanceConfig groupRebalanceConfig = new GroupRebalanceConfig(
+                100,
+                100,
+                100,
+                "group_id",
+                Optional.empty(),
+                RETRY_BACKOFF_MS,
+                true);
+        GroupState groupState = new GroupState(groupRebalanceConfig);
+        ApiVersions apiVersions = new ApiVersions();
+
+        Properties properties = new Properties();
+        properties.put(KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        properties.put(VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        properties.put(CommonClientConfigs.RETRY_BACKOFF_MS_CONFIG, RETRY_BACKOFF_MS);
+
+        this.config = new ConsumerConfig(properties);
+        IsolationLevel isolationLevel = getConfiguredIsolationLevel(config);
+        Metrics metrics = createMetrics(config, time);
+
+        this.subscriptions = createSubscriptionState(config, logContext);
+        this.metadata = spy(new ConsumerMetadata(config, subscriptions, logContext, new ClusterResourceListeners()));
+        this.fetchConfig = createFetchConfig(config);
+        this.metricsManager = createFetchMetricsManager(metrics);
+
+        KafkaClient client = new MockClient(time, Collections.singletonList(new Node(0, "localhost", 99)));
+        this.networkClientDelegate = spy(new NetworkClientDelegate(time,
+                config,
+                logContext,
+                client));
+        this.listOffsetsRequestManager = spy(new ListOffsetsRequestManager(subscriptions,
+                metadata,
+                isolationLevel,
+                time,
+                apiVersions,
+                logContext));
+        this.topicMetadataRequestManager = spy(new TopicMetadataRequestManager(logContext, config));
+        this.coordinatorRequestManager = spy(new CoordinatorRequestManager(time,
+                logContext,
+                RETRY_BACKOFF_MS,
+                errorEventHandler,
+                "group_id"));
+        this.commitRequestManager = spy(new CommitRequestManager(time,
+                logContext,
+                subscriptions,
+                config,
+                coordinatorRequestManager,
+                groupState));
+        this.requestManagers = new RequestManagers(logContext,
+                listOffsetsRequestManager,
+                topicMetadataRequestManager,
+                Optional.of(coordinatorRequestManager),
+                Optional.of(commitRequestManager));
+        this.applicationEventProcessor = spy(new ApplicationEventProcessor(
+                backgroundEventQueue,
+                requestManagers,
+                metadata,
+                logContext));
+        this.applicationEventProcessorSupplier = () -> applicationEventProcessor;
+        this.networkClientDelegateSupplier = () -> networkClientDelegate;
+        this.requestManagersSupplier = () -> requestManagers;
+    }
+
+    @Override
+    public void close() {
+        requestManagers.close();
+    }
+
+    public static class DefaultBackgroundThreadTestBuilder extends ConsumerTestBuilder {
+
+        final DefaultBackgroundThread<String, String> backgroundThread;
+
+        public DefaultBackgroundThreadTestBuilder() {
+            this.backgroundThread = new DefaultBackgroundThread<>(
+                    time,
+                    logContext,
+                    applicationEventQueue,
+                    applicationEventProcessorSupplier,
+                    networkClientDelegateSupplier,
+                    requestManagersSupplier);
+            this.backgroundThread.initializeResources();
+        }
+
+        @Override
+        public void close() {
+            backgroundThread.close();
+        }
+    }
+
+    public static class DefaultEventHandlerTestBuilder extends ConsumerTestBuilder {
+
+        final EventHandler eventHandler;
+
+        public DefaultEventHandlerTestBuilder() {
+            this.eventHandler = spy(new DefaultEventHandler<>(
+                    time,
+                    config,
+                    logContext,
+                    applicationEventQueue,
+                    backgroundEventQueue,
+                    applicationEventProcessorSupplier,
+                    networkClientDelegateSupplier,
+                    requestManagersSupplier));
+        }
+
+        @Override
+        public void close() {
+            eventHandler.close();
+        }
+    }
+
+    public static class PrototypeAsyncConsumerTestBuilder extends DefaultEventHandlerTestBuilder {
+
+        final PrototypeAsyncConsumer<String, String> consumer;
+
+        public PrototypeAsyncConsumerTestBuilder(Optional<String> groupIdOpt) {
+            FetchCollector<String, String> fetchCollector = new FetchCollector<>(logContext,
+                    metadata,
+                    subscriptions,
+                    fetchConfig,
+                    metricsManager,
+                    time);
+            this.consumer = spy(new PrototypeAsyncConsumer<>(logContext,
+                    time,
+                    metadata,
+                    eventHandler,
+                    groupIdOpt,
+                    new ConsumerInterceptors<>(Collections.emptyList()),
+                    subscriptions,
+                    3000,
+                    new FetchBuffer<>(logContext),
+                    fetchCollector));
+        }
+
+        @Override
+        public void close() {
+            consumer.close();
+        }
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerTestBuilder.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerTestBuilder.java
@@ -161,7 +161,6 @@ public class ConsumerTestBuilder implements Closeable {
                     applicationEventProcessorSupplier,
                     networkClientDelegateSupplier,
                     requestManagersSupplier);
-            this.backgroundThread.initializeResources();
         }
 
         @Override

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThreadTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThreadTest.java
@@ -64,7 +64,7 @@ public class DefaultBackgroundThreadTest {
     private CoordinatorRequestManager coordinatorRequestManager;
     private CommitRequestManager commitRequestManager;
     private RequestManagers requestManagers;
-    private DefaultBackgroundThread<String, String> backgroundThread;
+    private DefaultBackgroundThread backgroundThread;
 
     @BeforeEach
     public void setup() {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThreadTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThreadTest.java
@@ -26,7 +26,6 @@ import org.apache.kafka.clients.consumer.internals.events.TopicMetadataApplicati
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.message.FindCoordinatorRequestData;
 import org.apache.kafka.common.requests.FindCoordinatorRequest;
-import org.apache.kafka.common.utils.KafkaThread;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.test.TestUtils;
 import org.junit.jupiter.api.AfterEach;

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThreadTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThreadTest.java
@@ -63,7 +63,6 @@ public class DefaultBackgroundThreadTest {
     private BlockingQueue<ApplicationEvent> applicationEventQueue;
     private CoordinatorRequestManager coordinatorRequestManager;
     private CommitRequestManager commitRequestManager;
-    private RequestManagers requestManagers;
     private DefaultBackgroundThread backgroundThread;
 
     @BeforeEach
@@ -77,7 +76,6 @@ public class DefaultBackgroundThreadTest {
         this.applicationEventQueue = testBuilder.applicationEventQueue;
         this.coordinatorRequestManager = testBuilder.coordinatorRequestManager;
         this.commitRequestManager = testBuilder.commitRequestManager;
-        this.requestManagers = testBuilder.requestManagers;
         this.backgroundThread = testBuilder.backgroundThread;
     }
 
@@ -107,12 +105,10 @@ public class DefaultBackgroundThreadTest {
 
     @Test
     public void testApplicationEvent() {
-        CoordinatorRequestManager coordinatorRequestManager = requestManagers.coordinatorRequestManager.get();
-        CommitRequestManager commitRequestManager = requestManagers.commitRequestManager.get();
         when(coordinatorRequestManager.poll(anyLong())).thenReturn(mockPollCoordinatorResult());
         when(commitRequestManager.poll(anyLong())).thenReturn(mockPollCommitResult());
         ApplicationEvent e = new NoopApplicationEvent("noop event");
-        applicationEventQueue.add(e);
+        this.applicationEventQueue.add(e);
         backgroundThread.runOnce();
         verify(applicationEventProcessor, times(1)).process(e);
         backgroundThread.close();
@@ -153,8 +149,6 @@ public class DefaultBackgroundThreadTest {
 
     @Test
     void testFindCoordinator() {
-        CoordinatorRequestManager coordinatorRequestManager = requestManagers.coordinatorRequestManager.get();
-        CommitRequestManager commitRequestManager = requestManagers.commitRequestManager.get();
         when(coordinatorRequestManager.poll(anyLong())).thenReturn(mockPollCoordinatorResult());
         when(commitRequestManager.poll(anyLong())).thenReturn(mockPollCommitResult());
         backgroundThread.runOnce();

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThreadTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThreadTest.java
@@ -16,11 +16,8 @@
  */
 package org.apache.kafka.clients.consumer.internals;
 
-import org.apache.kafka.clients.GroupRebalanceConfig;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.internals.events.ApplicationEvent;
 import org.apache.kafka.clients.consumer.internals.events.ApplicationEventProcessor;
-import org.apache.kafka.clients.consumer.internals.events.BackgroundEvent;
 import org.apache.kafka.clients.consumer.internals.events.CommitApplicationEvent;
 import org.apache.kafka.clients.consumer.internals.events.ListOffsetsApplicationEvent;
 import org.apache.kafka.clients.consumer.internals.events.MetadataUpdateApplicationEvent;
@@ -29,11 +26,10 @@ import org.apache.kafka.clients.consumer.internals.events.TopicMetadataApplicati
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.message.FindCoordinatorRequestData;
 import org.apache.kafka.common.requests.FindCoordinatorRequest;
-import org.apache.kafka.common.serialization.StringDeserializer;
-import org.apache.kafka.common.utils.LogContext;
-import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.common.utils.KafkaThread;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.test.TestUtils;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -43,74 +39,60 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Properties;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.LinkedBlockingQueue;
 
-import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
-import static org.apache.kafka.clients.consumer.ConsumerConfig.RETRY_BACKOFF_MS_CONFIG;
-import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class DefaultBackgroundThreadTest {
-    private static final long RETRY_BACKOFF_MS = 100;
-    private final Properties properties = new Properties();
-    private MockTime time;
+
+    private ConsumerTestBuilder.DefaultBackgroundThreadTestBuilder testBuilder;
+    private Time time;
     private ConsumerMetadata metadata;
-    private NetworkClientDelegate networkClient;
-    private SubscriptionState subscriptionState;
-    private BlockingQueue<BackgroundEvent> backgroundEventsQueue;
-    private BlockingQueue<ApplicationEvent> applicationEventsQueue;
     private ApplicationEventProcessor applicationEventProcessor;
-    private CoordinatorRequestManager coordinatorManager;
-    private ListOffsetsRequestManager listOffsetsRequestManager;
-    private ErrorEventHandler errorEventHandler;
-    private final int requestTimeoutMs = 500;
-    private GroupState groupState;
-    private CommitRequestManager commitManager;
     private TopicMetadataRequestManager topicMetadataRequestManager;
+    private NetworkClientDelegate networkClientDelegate;
+    private BlockingQueue<ApplicationEvent> applicationEventQueue;
+    private CoordinatorRequestManager coordinatorRequestManager;
+    private CommitRequestManager commitRequestManager;
+    private RequestManagers requestManagers;
+    private DefaultBackgroundThread<String, String> backgroundThread;
 
     @BeforeEach
-    @SuppressWarnings("unchecked")
     public void setup() {
-        this.time = new MockTime(0);
-        this.metadata = mock(ConsumerMetadata.class);
-        this.networkClient = mock(NetworkClientDelegate.class);
-        this.subscriptionState = mock(SubscriptionState.class);
-        this.applicationEventsQueue = (BlockingQueue<ApplicationEvent>) mock(BlockingQueue.class);
-        this.backgroundEventsQueue = (BlockingQueue<BackgroundEvent>) mock(BlockingQueue.class);
-        this.applicationEventProcessor = mock(ApplicationEventProcessor.class);
-        this.coordinatorManager = mock(CoordinatorRequestManager.class);
-        this.listOffsetsRequestManager = mock(ListOffsetsRequestManager.class);
-        this.errorEventHandler = mock(ErrorEventHandler.class);
-        GroupRebalanceConfig rebalanceConfig = new GroupRebalanceConfig(
-                100,
-                100,
-                100,
-                "group_id",
-                Optional.empty(),
-                100,
-                true);
-        this.groupState = new GroupState(rebalanceConfig);
-        this.commitManager = mock(CommitRequestManager.class);
-        this.topicMetadataRequestManager = mock(TopicMetadataRequestManager.class);
+        this.testBuilder = new ConsumerTestBuilder.DefaultBackgroundThreadTestBuilder();
+        this.time = testBuilder.time;
+        this.metadata = testBuilder.metadata;
+        this.applicationEventProcessor = testBuilder.applicationEventProcessor;
+        this.topicMetadataRequestManager = testBuilder.topicMetadataRequestManager;
+        this.networkClientDelegate = testBuilder.networkClientDelegate;
+        this.applicationEventQueue = testBuilder.applicationEventQueue;
+        this.coordinatorRequestManager = testBuilder.coordinatorRequestManager;
+        this.commitRequestManager = testBuilder.commitRequestManager;
+        this.requestManagers = testBuilder.requestManagers;
+        this.backgroundThread = testBuilder.backgroundThread;
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (testBuilder != null)
+            testBuilder.close();
     }
 
     @Test
     public void testStartupAndTearDown() throws InterruptedException {
-        DefaultBackgroundThread backgroundThread = mockBackgroundThread();
-        backgroundThread.start();
+        assertFalse(backgroundThread.isRunning());
 
+        KafkaThread ioThread = new KafkaThread(PrototypeAsyncConsumer.NETWORK_THREAD_PREFIX, backgroundThread, true);
+        ioThread.start();
         // There's a nonzero amount of time between starting the thread and having it
         // begin to execute our code. Wait for a bit before checking...
         int maxWaitMs = 1000;
@@ -125,13 +107,12 @@ public class DefaultBackgroundThreadTest {
 
     @Test
     public void testApplicationEvent() {
-        this.applicationEventsQueue = new LinkedBlockingQueue<>();
-        this.backgroundEventsQueue = new LinkedBlockingQueue<>();
-        when(coordinatorManager.poll(anyLong())).thenReturn(mockPollCoordinatorResult());
-        when(commitManager.poll(anyLong())).thenReturn(mockPollCommitResult());
-        DefaultBackgroundThread backgroundThread = mockBackgroundThread();
+        CoordinatorRequestManager coordinatorRequestManager = requestManagers.coordinatorRequestManager.get();
+        CommitRequestManager commitRequestManager = requestManagers.commitRequestManager.get();
+        when(coordinatorRequestManager.poll(anyLong())).thenReturn(mockPollCoordinatorResult());
+        when(commitRequestManager.poll(anyLong())).thenReturn(mockPollCommitResult());
         ApplicationEvent e = new NoopApplicationEvent("noop event");
-        this.applicationEventsQueue.add(e);
+        applicationEventQueue.add(e);
         backgroundThread.runOnce();
         verify(applicationEventProcessor, times(1)).process(e);
         backgroundThread.close();
@@ -139,16 +120,10 @@ public class DefaultBackgroundThreadTest {
 
     @Test
     public void testMetadataUpdateEvent() {
-        this.applicationEventsQueue = new LinkedBlockingQueue<>();
-        this.backgroundEventsQueue = new LinkedBlockingQueue<>();
-        this.applicationEventProcessor = new ApplicationEventProcessor(this.backgroundEventsQueue,
-                mockRequestManagers(),
-                metadata);
-        when(coordinatorManager.poll(anyLong())).thenReturn(mockPollCoordinatorResult());
-        when(commitManager.poll(anyLong())).thenReturn(mockPollCommitResult());
-        DefaultBackgroundThread backgroundThread = mockBackgroundThread();
+        when(coordinatorRequestManager.poll(anyLong())).thenReturn(mockPollCoordinatorResult());
+        when(commitRequestManager.poll(anyLong())).thenReturn(mockPollCommitResult());
         ApplicationEvent e = new MetadataUpdateApplicationEvent(time.milliseconds());
-        this.applicationEventsQueue.add(e);
+        this.applicationEventQueue.add(e);
         backgroundThread.runOnce();
         verify(metadata).requestUpdateForNewTopics();
         backgroundThread.close();
@@ -156,13 +131,10 @@ public class DefaultBackgroundThreadTest {
 
     @Test
     public void testCommitEvent() {
-        this.applicationEventsQueue = new LinkedBlockingQueue<>();
-        this.backgroundEventsQueue = new LinkedBlockingQueue<>();
-        when(coordinatorManager.poll(anyLong())).thenReturn(mockPollCoordinatorResult());
-        when(commitManager.poll(anyLong())).thenReturn(mockPollCommitResult());
-        DefaultBackgroundThread backgroundThread = mockBackgroundThread();
+        when(coordinatorRequestManager.poll(anyLong())).thenReturn(mockPollCoordinatorResult());
+        when(commitRequestManager.poll(anyLong())).thenReturn(mockPollCommitResult());
         ApplicationEvent e = new CommitApplicationEvent(new HashMap<>());
-        this.applicationEventsQueue.add(e);
+        this.applicationEventQueue.add(e);
         backgroundThread.runOnce();
         verify(applicationEventProcessor).process(any(CommitApplicationEvent.class));
         backgroundThread.close();
@@ -170,35 +142,31 @@ public class DefaultBackgroundThreadTest {
 
     @Test
     public void testListOffsetsEventIsProcessed() {
-        this.applicationEventsQueue = new LinkedBlockingQueue<>();
-        this.backgroundEventsQueue = new LinkedBlockingQueue<>();
-        DefaultBackgroundThread backgroundThread = mockBackgroundThread();
         Map<TopicPartition, Long> timestamps = Collections.singletonMap(new TopicPartition("topic1", 1), 5L);
         ApplicationEvent e = new ListOffsetsApplicationEvent(timestamps, true);
-        this.applicationEventsQueue.add(e);
+        this.applicationEventQueue.add(e);
         backgroundThread.runOnce();
         verify(applicationEventProcessor).process(any(ListOffsetsApplicationEvent.class));
-        assertTrue(applicationEventsQueue.isEmpty());
+        assertTrue(applicationEventQueue.isEmpty());
         backgroundThread.close();
     }
 
     @Test
     void testFindCoordinator() {
-        DefaultBackgroundThread backgroundThread = mockBackgroundThread();
-        when(this.coordinatorManager.poll(anyLong())).thenReturn(mockPollCoordinatorResult());
-        when(this.commitManager.poll(anyLong())).thenReturn(mockPollCommitResult());
+        CoordinatorRequestManager coordinatorRequestManager = requestManagers.coordinatorRequestManager.get();
+        CommitRequestManager commitRequestManager = requestManagers.commitRequestManager.get();
+        when(coordinatorRequestManager.poll(anyLong())).thenReturn(mockPollCoordinatorResult());
+        when(commitRequestManager.poll(anyLong())).thenReturn(mockPollCommitResult());
         backgroundThread.runOnce();
-        Mockito.verify(coordinatorManager, times(1)).poll(anyLong());
-        Mockito.verify(networkClient, times(1)).poll(anyLong(), anyLong());
+        Mockito.verify(coordinatorRequestManager, times(1)).poll(anyLong());
+        Mockito.verify(networkClientDelegate, times(1)).poll(anyLong(), anyLong());
         backgroundThread.close();
     }
 
     @Test
     void testFetchTopicMetadata() {
-        this.applicationEventsQueue = new LinkedBlockingQueue<>();
-        DefaultBackgroundThread backgroundThread = mockBackgroundThread();
         when(this.topicMetadataRequestManager.requestTopicMetadata(Optional.of(anyString()))).thenReturn(new CompletableFuture<>());
-        this.applicationEventsQueue.add(new TopicMetadataApplicationEvent("topic"));
+        this.applicationEventQueue.add(new TopicMetadataApplicationEvent("topic"));
         backgroundThread.runOnce();
         verify(applicationEventProcessor).process(any(TopicMetadataApplicationEvent.class));
         backgroundThread.close();
@@ -206,11 +174,10 @@ public class DefaultBackgroundThreadTest {
 
     @Test
     void testPollResultTimer() {
-        DefaultBackgroundThread backgroundThread = mockBackgroundThread();
-        // purposely setting a non MAX time to ensure it is returning Long.MAX_VALUE upon success
+        // purposely setting a non-MAX time to ensure it is returning Long.MAX_VALUE upon success
         NetworkClientDelegate.PollResult success = new NetworkClientDelegate.PollResult(
                 10,
-                Collections.singletonList(findCoordinatorUnsentRequest(time, requestTimeoutMs)));
+                Collections.singletonList(findCoordinatorUnsentRequest()));
         assertEquals(10, backgroundThread.handlePollResult(success));
 
         NetworkClientDelegate.PollResult failure = new NetworkClientDelegate.PollResult(
@@ -219,60 +186,26 @@ public class DefaultBackgroundThreadTest {
         assertEquals(10, backgroundThread.handlePollResult(failure));
     }
 
-    private RequestManagers mockRequestManagers() {
-        return new RequestManagers(
-            listOffsetsRequestManager,
-            topicMetadataRequestManager,
-            Optional.of(coordinatorManager),
-            Optional.of(commitManager));
-    }
-
-    private static NetworkClientDelegate.UnsentRequest findCoordinatorUnsentRequest(
-            final Time time,
-            final long timeout
-    ) {
+    private NetworkClientDelegate.UnsentRequest findCoordinatorUnsentRequest() {
         NetworkClientDelegate.UnsentRequest req = new NetworkClientDelegate.UnsentRequest(
                 new FindCoordinatorRequest.Builder(
                         new FindCoordinatorRequestData()
                                 .setKeyType(FindCoordinatorRequest.CoordinatorType.TRANSACTION.id())
                                 .setKey("foobar")),
-            Optional.empty());
-        req.setTimer(time, timeout);
+                Optional.empty());
+        req.setTimer(time, ConsumerTestBuilder.REQUEST_TIMEOUT_MS);
         return req;
-    }
-
-    private DefaultBackgroundThread mockBackgroundThread() {
-        properties.put(KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-        properties.put(VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-        properties.put(RETRY_BACKOFF_MS_CONFIG, RETRY_BACKOFF_MS);
-
-        return new DefaultBackgroundThread(this.time,
-            new ConsumerConfig(properties),
-            new LogContext(),
-            applicationEventsQueue,
-            backgroundEventsQueue,
-            this.metadata,
-            this.networkClient,
-            this.subscriptionState,
-            this.groupState,
-            this.errorEventHandler,
-            applicationEventProcessor,
-            this.coordinatorManager,
-            this.commitManager,
-            this.listOffsetsRequestManager,
-            this.topicMetadataRequestManager);
-
     }
 
     private NetworkClientDelegate.PollResult mockPollCoordinatorResult() {
         return new NetworkClientDelegate.PollResult(
-            RETRY_BACKOFF_MS,
-            Collections.singletonList(findCoordinatorUnsentRequest(time, requestTimeoutMs)));
+                ConsumerTestBuilder.RETRY_BACKOFF_MS,
+                Collections.singletonList(findCoordinatorUnsentRequest()));
     }
 
     private NetworkClientDelegate.PollResult mockPollCommitResult() {
         return new NetworkClientDelegate.PollResult(
-            RETRY_BACKOFF_MS,
-            Collections.singletonList(findCoordinatorUnsentRequest(time, requestTimeoutMs)));
+                ConsumerTestBuilder.RETRY_BACKOFF_MS,
+                Collections.singletonList(findCoordinatorUnsentRequest()));
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThreadTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThreadTest.java
@@ -56,12 +56,12 @@ public class DefaultBackgroundThreadTest {
     private ConsumerTestBuilder.DefaultBackgroundThreadTestBuilder testBuilder;
     private Time time;
     private ConsumerMetadata metadata;
-    private ApplicationEventProcessor applicationEventProcessor;
-    private TopicMetadataRequestManager topicMetadataRequestManager;
-    private NetworkClientDelegate networkClientDelegate;
+    private NetworkClientDelegate networkClient;
     private BlockingQueue<ApplicationEvent> applicationEventQueue;
+    private ApplicationEventProcessor applicationEventProcessor;
     private CoordinatorRequestManager coordinatorRequestManager;
     private CommitRequestManager commitRequestManager;
+    private TopicMetadataRequestManager topicMetadataRequestManager;
     private DefaultBackgroundThread backgroundThread;
 
     @BeforeEach
@@ -69,12 +69,12 @@ public class DefaultBackgroundThreadTest {
         this.testBuilder = new ConsumerTestBuilder.DefaultBackgroundThreadTestBuilder();
         this.time = testBuilder.time;
         this.metadata = testBuilder.metadata;
-        this.applicationEventProcessor = testBuilder.applicationEventProcessor;
-        this.topicMetadataRequestManager = testBuilder.topicMetadataRequestManager;
-        this.networkClientDelegate = testBuilder.networkClientDelegate;
+        this.networkClient = testBuilder.networkClientDelegate;
         this.applicationEventQueue = testBuilder.applicationEventQueue;
+        this.applicationEventProcessor = testBuilder.applicationEventProcessor;
         this.coordinatorRequestManager = testBuilder.coordinatorRequestManager;
         this.commitRequestManager = testBuilder.commitRequestManager;
+        this.topicMetadataRequestManager = testBuilder.topicMetadataRequestManager;
         this.backgroundThread = testBuilder.backgroundThread;
     }
 
@@ -156,7 +156,7 @@ public class DefaultBackgroundThreadTest {
         backgroundThread.initializeResources();
         backgroundThread.runOnce();
         Mockito.verify(coordinatorRequestManager, times(1)).poll(anyLong());
-        Mockito.verify(networkClientDelegate, times(1)).poll(anyLong(), anyLong());
+        Mockito.verify(networkClient, times(1)).poll(anyLong(), anyLong());
         backgroundThread.close();
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/DefaultEventHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/DefaultEventHandlerTest.java
@@ -32,14 +32,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class DefaultEventHandlerTest {
 
     private ConsumerTestBuilder.DefaultEventHandlerTestBuilder testBuilder;
-    private EventHandler eventHandler;
-    private BlockingQueue<ApplicationEvent> applicationEventQueue;
+    private EventHandler handler;
+    private BlockingQueue<ApplicationEvent> aq;
 
     @BeforeEach
     public void setup() {
         testBuilder = new ConsumerTestBuilder.DefaultEventHandlerTestBuilder();
-        eventHandler = testBuilder.eventHandler;
-        applicationEventQueue = testBuilder.applicationEventQueue;
+        handler = testBuilder.eventHandler;
+        aq = testBuilder.applicationEventQueue;
     }
 
     @AfterEach
@@ -50,10 +50,9 @@ public class DefaultEventHandlerTest {
 
     @Test
     public void testBasicHandlerOps() {
-        assertTrue(eventHandler.isEmpty());
-        assertFalse(eventHandler.poll().isPresent());
-        eventHandler.add(new NoopApplicationEvent("test"));
-        assertEquals(1, applicationEventQueue.size());
-        eventHandler.close();
+        assertTrue(handler.isEmpty());
+        assertFalse(handler.poll().isPresent());
+        handler.add(new NoopApplicationEvent("test"));
+        assertEquals(1, aq.size());
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumerTest.java
@@ -68,7 +68,7 @@ public class PrototypeAsyncConsumerTest {
 
     private static final Optional<String> DEFAULT_GROUP_ID = Optional.of("group.id");
 
-    private ConsumerTestBuilder.PrototypeAsyncConsumerTestBuilder consumerBuilder;
+    private ConsumerTestBuilder.PrototypeAsyncConsumerTestBuilder testBuilder;
     private EventHandler eventHandler;
     private PrototypeAsyncConsumer<String, String> consumer;
 
@@ -79,19 +79,19 @@ public class PrototypeAsyncConsumerTest {
 
     @AfterEach
     public void cleanup() {
-        if (consumer != null)
-            consumer.close();
+        if (testBuilder != null)
+            testBuilder.close();
     }
 
     private void setup(Optional<String> groupIdOpt) {
-        consumerBuilder = new ConsumerTestBuilder.PrototypeAsyncConsumerTestBuilder(groupIdOpt);
-        eventHandler = consumerBuilder.eventHandler;
-        consumer = consumerBuilder.consumer;
+        testBuilder = new ConsumerTestBuilder.PrototypeAsyncConsumerTestBuilder(groupIdOpt);
+        eventHandler = testBuilder.eventHandler;
+        consumer = testBuilder.consumer;
     }
 
     @Test
     public void testSuccessfulStartupShutdown() {
-        assertDoesNotThrow(() -> consumerBuilder.consumer.close());
+        assertDoesNotThrow(() -> consumer.close());
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumerTest.java
@@ -16,12 +16,10 @@
  */
 package org.apache.kafka.clients.consumer.internals;
 
-import org.apache.kafka.clients.consumer.Consumer;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
 import org.apache.kafka.clients.consumer.OffsetCommitCallback;
-import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.clients.consumer.internals.events.ApplicationEvent;
 import org.apache.kafka.clients.consumer.internals.events.CommitApplicationEvent;
 import org.apache.kafka.clients.consumer.internals.events.EventHandler;
 import org.apache.kafka.clients.consumer.internals.events.ListOffsetsApplicationEvent;
@@ -30,13 +28,7 @@ import org.apache.kafka.clients.consumer.internals.events.OffsetFetchApplication
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.InvalidGroupIdException;
-import org.apache.kafka.common.internals.ClusterResourceListeners;
-import org.apache.kafka.common.metrics.Metrics;
-import org.apache.kafka.common.serialization.Deserializer;
-import org.apache.kafka.common.serialization.StringDeserializer;
-import org.apache.kafka.common.utils.LogContext;
-import org.apache.kafka.common.utils.MockTime;
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.test.TestUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -48,72 +40,64 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.singleton;
-import static org.apache.kafka.clients.consumer.ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG;
-import static org.apache.kafka.clients.consumer.ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG;
-import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
-import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class PrototypeAsyncConsumerTest {
 
-    private Consumer<?, ?> consumer;
-    private final Map<String, Object> consumerProps = new HashMap<>();
+    private static final Optional<String> DEFAULT_GROUP_ID = Optional.of("group.id");
 
-    private final Time time = new MockTime();
-    private LogContext logContext;
-    private SubscriptionState subscriptions;
+    private ConsumerTestBuilder.PrototypeAsyncConsumerTestBuilder consumerBuilder;
     private EventHandler eventHandler;
-    private Metrics metrics;
-    private String groupId = "group.id";
-    private ConsumerConfig config;
+    private PrototypeAsyncConsumer<String, String> consumer;
 
     @BeforeEach
     public void setup() {
-        injectConsumerConfigs();
-        this.config = new ConsumerConfig(consumerProps);
-        this.logContext = new LogContext();
-        this.subscriptions = mock(SubscriptionState.class);
-        this.eventHandler = mock(DefaultEventHandler.class);
-        this.metrics = new Metrics(time);
+        setup(DEFAULT_GROUP_ID);
     }
 
     @AfterEach
     public void cleanup() {
-        if (consumer != null) {
-            consumer.close(Duration.ZERO);
-        }
+        if (consumer != null)
+            consumer.close();
+    }
+
+    private void setup(Optional<String> groupIdOpt) {
+        consumerBuilder = new ConsumerTestBuilder.PrototypeAsyncConsumerTestBuilder(groupIdOpt);
+        eventHandler = consumerBuilder.eventHandler;
+        consumer = consumerBuilder.consumer;
     }
 
     @Test
     public void testSuccessfulStartupShutdown() {
-        consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
-        assertDoesNotThrow(() -> consumer.close());
+        assertDoesNotThrow(() -> consumerBuilder.consumer.close());
     }
 
     @Test
     public void testInvalidGroupId() {
-        this.groupId = null;
-        consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
+        cleanup();
+        setup(Optional.empty());
         assertThrows(InvalidGroupIdException.class, () -> consumer.committed(new HashSet<>()));
     }
 
@@ -124,17 +108,13 @@ public class PrototypeAsyncConsumerTest {
         offsets.put(new TopicPartition("my-topic", 0), new OffsetAndMetadata(100L));
         offsets.put(new TopicPartition("my-topic", 1), new OffsetAndMetadata(200L));
 
-        PrototypeAsyncConsumer<?, ?> mockedConsumer = spy(newConsumer(time, new StringDeserializer(), new StringDeserializer()));
-        doReturn(future).when(mockedConsumer).commit(offsets);
-        mockedConsumer.commitAsync(offsets, null);
+        doReturn(future).when(consumer).commit(offsets);
+        consumer.commitAsync(offsets, null);
         future.complete(null);
-        TestUtils.waitForCondition(() -> future.isDone(),
-                2000,
-                "commit future should complete");
+        TestUtils.waitForCondition(future::isDone, 2000, "commit future should complete");
 
         assertFalse(future.isCompletedExceptionally());
     }
-
 
     @Test
     public void testCommitAsync_UserSuppliedCallback() {
@@ -144,35 +124,35 @@ public class PrototypeAsyncConsumerTest {
         offsets.put(new TopicPartition("my-topic", 0), new OffsetAndMetadata(100L));
         offsets.put(new TopicPartition("my-topic", 1), new OffsetAndMetadata(200L));
 
-        PrototypeAsyncConsumer<?, ?> consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
-        PrototypeAsyncConsumer<?, ?> mockedConsumer = spy(consumer);
-        doReturn(future).when(mockedConsumer).commit(offsets);
+        doReturn(future).when(consumer).commit(offsets);
         OffsetCommitCallback customCallback = mock(OffsetCommitCallback.class);
-        mockedConsumer.commitAsync(offsets, customCallback);
+        consumer.commitAsync(offsets, customCallback);
         future.complete(null);
         verify(customCallback).onComplete(offsets, null);
     }
 
     @Test
     public void testCommitted() {
-        Set<TopicPartition> mockTopicPartitions = mockTopicPartitionOffset().keySet();
-        MockedConstruction<OffsetFetchApplicationEvent> mockedCtor = null;
+        MockedConstruction.MockInitializer<OffsetFetchApplicationEvent> mockInitializer = (mock, ctx) -> {
+            // Make sure that get returns map but also that the type of the event returns something so that
+            // the DefaultEventProcessor doesn't choke on a null type.
+            when(mock.get(any())).thenReturn(new HashMap<>());
+            when(mock.type()).thenReturn(ApplicationEvent.Type.FETCH_COMMITTED_OFFSET);
+        };
 
-        try {
-            mockedCtor = mockConstruction(OffsetFetchApplicationEvent.class, (mock, ctx) -> when(mock.get(any())).thenReturn(new HashMap<>()));
-            consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
+        try (MockedConstruction<OffsetFetchApplicationEvent> construction = mockConstruction(OffsetFetchApplicationEvent.class, mockInitializer)) {
+            Set<TopicPartition> mockTopicPartitions = mockTopicPartitionOffset().keySet();
             assertDoesNotThrow(() -> consumer.committed(mockTopicPartitions, Duration.ofMillis(1)));
-            verify(eventHandler).addAndGet(ArgumentMatchers.isA(OffsetFetchApplicationEvent.class), any(Duration.class));
-        } finally {
-            if (mockedCtor != null)
-                mockedCtor.close();
+            List<OffsetFetchApplicationEvent> constructedEvents = construction.constructed();
+            assertNotNull(constructedEvents);
+            assertEquals(1, constructedEvents.size());
+            OffsetFetchApplicationEvent event = constructedEvents.get(0);
+            verify(eventHandler).addAndGet(eq(event), any(Duration.class));
         }
     }
 
     @Test
     public void testAssign() {
-        this.subscriptions = new SubscriptionState(logContext, OffsetResetStrategy.EARLIEST);
-        this.consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
         final TopicPartition tp = new TopicPartition("foo", 3);
         consumer.assign(singleton(tp));
         assertTrue(consumer.subscription().isEmpty());
@@ -183,13 +163,11 @@ public class PrototypeAsyncConsumerTest {
 
     @Test
     public void testAssignOnNullTopicPartition() {
-        consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
         assertThrows(IllegalArgumentException.class, () -> consumer.assign(null));
     }
 
     @Test
     public void testAssignOnEmptyTopicPartition() {
-        consumer = spy(newConsumer(time, new StringDeserializer(), new StringDeserializer()));
         consumer.assign(Collections.emptyList());
         assertTrue(consumer.subscription().isEmpty());
         assertTrue(consumer.assignment().isEmpty());
@@ -197,21 +175,17 @@ public class PrototypeAsyncConsumerTest {
 
     @Test
     public void testAssignOnNullTopicInPartition() {
-        consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
         assertThrows(IllegalArgumentException.class, () -> consumer.assign(singleton(new TopicPartition(null, 0))));
     }
 
     @Test
     public void testAssignOnEmptyTopicInPartition() {
-        consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
         assertThrows(IllegalArgumentException.class, () -> consumer.assign(singleton(new TopicPartition("  ", 0))));
     }
 
     @Test
     public void testBeginningOffsetsFailsIfNullPartitions() {
-        consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
-        assertThrows(NullPointerException.class, () -> consumer.beginningOffsets(null,
-                Duration.ofMillis(1)));
+        assertThrows(NullPointerException.class, () -> consumer.beginningOffsets(null, Duration.ofMillis(1)));
     }
 
     @Test
@@ -219,8 +193,7 @@ public class PrototypeAsyncConsumerTest {
         Map<TopicPartition, OffsetAndTimestamp> expectedOffsetsAndTimestamp =
                 mockOffsetAndTimestamp();
         Set<TopicPartition> partitions = expectedOffsetsAndTimestamp.keySet();
-        when(eventHandler.addAndGet(any(), any())).thenReturn(expectedOffsetsAndTimestamp);
-        consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
+        doReturn(expectedOffsetsAndTimestamp).when(eventHandler).addAndGet(any(), any());
         Map<TopicPartition, Long> result =
                 assertDoesNotThrow(() -> consumer.beginningOffsets(partitions,
                         Duration.ofMillis(1)));
@@ -236,9 +209,7 @@ public class PrototypeAsyncConsumerTest {
         Set<TopicPartition> partitions = mockTopicPartitionOffset().keySet();
         Throwable eventProcessingFailure = new KafkaException("Unexpected failure " +
                 "processing List Offsets event");
-        when(eventHandler.addAndGet(any(), any())).thenThrow(eventProcessingFailure);
-
-        consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
+        doThrow(eventProcessingFailure).when(eventHandler).addAndGet(any(), any());
         Throwable consumerError = assertThrows(KafkaException.class,
                 () -> consumer.beginningOffsets(partitions,
                         Duration.ofMillis(1)));
@@ -248,9 +219,8 @@ public class PrototypeAsyncConsumerTest {
 
     @Test
     public void testBeginningOffsetsTimeoutOnEventProcessingTimeout() {
-        when(eventHandler.addAndGet(any(), any())).thenThrow(new TimeoutException());
-        consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
-        assertThrows(org.apache.kafka.common.errors.TimeoutException.class,
+        doThrow(new TimeoutException()).when(eventHandler).addAndGet(any(), any());
+        assertThrows(TimeoutException.class,
                 () -> consumer.beginningOffsets(
                         Collections.singletonList(new TopicPartition("t1", 0)),
                         Duration.ofMillis(1)));
@@ -260,7 +230,6 @@ public class PrototypeAsyncConsumerTest {
 
     @Test
     public void testOffsetsForTimesOnNullPartitions() {
-        consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
         assertThrows(NullPointerException.class, () -> consumer.offsetsForTimes(null,
                 Duration.ofMillis(1)));
     }
@@ -270,8 +239,7 @@ public class PrototypeAsyncConsumerTest {
         Map<TopicPartition, OffsetAndTimestamp> expectedResult = mockOffsetAndTimestamp();
         Map<TopicPartition, Long> timestampToSearch = mockTimestampToSearch();
 
-        consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
-        when(eventHandler.addAndGet(any(), any())).thenReturn(expectedResult);
+        doReturn(expectedResult).when(eventHandler).addAndGet(any(), any());
         Map<TopicPartition, OffsetAndTimestamp> result =
                 assertDoesNotThrow(() -> consumer.offsetsForTimes(timestampToSearch, Duration.ofMillis(1)));
         assertEquals(expectedResult, result);
@@ -289,7 +257,6 @@ public class PrototypeAsyncConsumerTest {
                 Collections.singletonMap(tp, null);
         Map<TopicPartition, Long> timestampToSearch = Collections.singletonMap(tp, 5L);
 
-        consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
         Map<TopicPartition, OffsetAndTimestamp> result =
                 assertDoesNotThrow(() -> consumer.offsetsForTimes(timestampToSearch,
                         Duration.ofMillis(0)));
@@ -323,34 +290,6 @@ public class PrototypeAsyncConsumerTest {
         timestampToSearch.put(t0, 1L);
         timestampToSearch.put(t1, 2L);
         return timestampToSearch;
-    }
-
-    private ConsumerMetadata createMetadata(SubscriptionState subscription) {
-        return new ConsumerMetadata(0, Long.MAX_VALUE, false, false,
-                subscription, new LogContext(), new ClusterResourceListeners());
-    }
-
-    private void injectConsumerConfigs() {
-        consumerProps.put(BOOTSTRAP_SERVERS_CONFIG, "localhost:9999");
-        consumerProps.put(DEFAULT_API_TIMEOUT_MS_CONFIG, "60000");
-        consumerProps.put(KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-        consumerProps.put(VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-    }
-
-    private PrototypeAsyncConsumer<?, ?> newConsumer(final Time time,
-                                                     final Deserializer<?> keyDeserializer,
-                                                     final Deserializer<?> valueDeserializer) {
-        consumerProps.put(KEY_DESERIALIZER_CLASS_CONFIG, keyDeserializer.getClass());
-        consumerProps.put(VALUE_DESERIALIZER_CLASS_CONFIG, valueDeserializer.getClass());
-
-        return new PrototypeAsyncConsumer<>(time,
-                logContext,
-                config,
-                subscriptions,
-                eventHandler,
-                metrics,
-                Optional.ofNullable(this.groupId),
-                config.getInt(DEFAULT_API_TIMEOUT_MS_CONFIG));
     }
 }
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/TopicMetadataRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/TopicMetadataRequestManagerTest.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.clients.consumer.internals;
 
 import org.apache.kafka.clients.ClientResponse;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.Node;
@@ -29,9 +28,8 @@ import org.apache.kafka.common.requests.MetadataRequest;
 import org.apache.kafka.common.requests.MetadataResponse;
 import org.apache.kafka.common.requests.RequestHeader;
 import org.apache.kafka.common.requests.RequestTestUtils;
-import org.apache.kafka.common.serialization.StringDeserializer;
-import org.apache.kafka.common.utils.LogContext;
-import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.common.utils.Time;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -46,33 +44,29 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 
-import static org.apache.kafka.clients.consumer.ConsumerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG;
-import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
-import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TopicMetadataRequestManagerTest {
-    private MockTime time;
-    private TopicMetadataRequestManager topicMetadataRequestManager;
 
-    private Properties props;
+    private ConsumerTestBuilder.DefaultEventHandlerTestBuilder testBuilder;
+    private Time time;
+    private TopicMetadataRequestManager topicMetadataRequestManager;
 
     @BeforeEach
     public void setup() {
-        this.time = new MockTime();
-        this.props = new Properties();
-        this.props.put(ConsumerConfig.RETRY_BACKOFF_MS_CONFIG, 100);
-        this.props.put(ALLOW_AUTO_CREATE_TOPICS_CONFIG, false);
-        this.props.put(KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-        this.props.put(VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-        this.topicMetadataRequestManager = new TopicMetadataRequestManager(
-            new LogContext(),
-            new ConsumerConfig(props));
+        testBuilder = new ConsumerTestBuilder.DefaultEventHandlerTestBuilder();
+        time = testBuilder.time;
+        topicMetadataRequestManager = testBuilder.topicMetadataRequestManager;
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (testBuilder != null)
+            testBuilder.close();
     }
 
     @ParameterizedTest
@@ -91,10 +85,9 @@ public class TopicMetadataRequestManagerTest {
         this.topicMetadataRequestManager.requestTopicMetadata(Optional.of("hello"));
         this.time.sleep(100);
         NetworkClientDelegate.PollResult res = this.topicMetadataRequestManager.poll(this.time.milliseconds());
-        res.unsentRequests.get(0).future().complete(buildTopicMetadataClientResponse(
-            res.unsentRequests.get(0),
-            topic,
-            error));
+        assertEquals(1, res.unsentRequests.size());
+        NetworkClientDelegate.UnsentRequest request = res.unsentRequests.get(0);
+        request.future().complete(buildTopicMetadataClientResponse(request, topic, error));
         List<TopicMetadataRequestManager.CompletableTopicMetadataRequest> inflights = this.topicMetadataRequestManager.inflightRequests();
 
         if (shouldRetry) {
@@ -119,20 +112,17 @@ public class TopicMetadataRequestManagerTest {
     @Test
     public void testSendingTheSameRequest() {
         final String topic = "hello";
-        CompletableFuture<Map<String, List<PartitionInfo>>> future = this.topicMetadataRequestManager.requestTopicMetadata(Optional.of(topic));
-        CompletableFuture<Map<String, List<PartitionInfo>>> future2 =
-            this.topicMetadataRequestManager.requestTopicMetadata(Optional.of(topic));
+        CompletableFuture<Map<String, List<PartitionInfo>>> future1 = topicMetadataRequestManager.requestTopicMetadata(Optional.of(topic));
+        CompletableFuture<Map<String, List<PartitionInfo>>> future2 = topicMetadataRequestManager.requestTopicMetadata(Optional.of(topic));
         this.time.sleep(100);
         NetworkClientDelegate.PollResult res = this.topicMetadataRequestManager.poll(this.time.milliseconds());
         assertEquals(1, res.unsentRequests.size());
 
-        res.unsentRequests.get(0).future().complete(buildTopicMetadataClientResponse(
-            res.unsentRequests.get(0),
-            topic,
-            Errors.NONE));
+        NetworkClientDelegate.UnsentRequest request = res.unsentRequests.get(0);
+        request.future().complete(buildTopicMetadataClientResponse(request, topic, Errors.NONE));
 
-        assertTrue(future.isDone());
-        assertFalse(future.isCompletedExceptionally());
+        assertTrue(future1.isDone());
+        assertFalse(future1.isCompletedExceptionally());
         assertTrue(future2.isDone());
         assertFalse(future2.isCompletedExceptionally());
     }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/TopicMetadataRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/TopicMetadataRequestManagerTest.java
@@ -112,9 +112,9 @@ public class TopicMetadataRequestManagerTest {
     @Test
     public void testSendingTheSameRequest() {
         final String topic = "hello";
-        CompletableFuture<Map<String, List<PartitionInfo>>> future = topicMetadataRequestManager.requestTopicMetadata(Optional.of(topic));
+        CompletableFuture<Map<String, List<PartitionInfo>>> future = this.topicMetadataRequestManager.requestTopicMetadata(Optional.of(topic));
         CompletableFuture<Map<String, List<PartitionInfo>>> future2 =
-            topicMetadataRequestManager.requestTopicMetadata(Optional.of(topic));
+            this.topicMetadataRequestManager.requestTopicMetadata(Optional.of(topic));
         this.time.sleep(100);
         NetworkClientDelegate.PollResult res = this.topicMetadataRequestManager.poll(this.time.milliseconds());
         assertEquals(1, res.unsentRequests.size());

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/TopicMetadataRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/TopicMetadataRequestManagerTest.java
@@ -112,8 +112,9 @@ public class TopicMetadataRequestManagerTest {
     @Test
     public void testSendingTheSameRequest() {
         final String topic = "hello";
-        CompletableFuture<Map<String, List<PartitionInfo>>> future1 = topicMetadataRequestManager.requestTopicMetadata(Optional.of(topic));
-        CompletableFuture<Map<String, List<PartitionInfo>>> future2 = topicMetadataRequestManager.requestTopicMetadata(Optional.of(topic));
+        CompletableFuture<Map<String, List<PartitionInfo>>> future = topicMetadataRequestManager.requestTopicMetadata(Optional.of(topic));
+        CompletableFuture<Map<String, List<PartitionInfo>>> future2 =
+            topicMetadataRequestManager.requestTopicMetadata(Optional.of(topic));
         this.time.sleep(100);
         NetworkClientDelegate.PollResult res = this.topicMetadataRequestManager.poll(this.time.milliseconds());
         assertEquals(1, res.unsentRequests.size());
@@ -121,8 +122,8 @@ public class TopicMetadataRequestManagerTest {
         NetworkClientDelegate.UnsentRequest request = res.unsentRequests.get(0);
         request.future().complete(buildTopicMetadataClientResponse(request, topic, Errors.NONE));
 
-        assertTrue(future1.isDone());
-        assertFalse(future1.isCompletedExceptionally());
+        assertTrue(future.isDone());
+        assertFalse(future.isCompletedExceptionally());
         assertTrue(future2.isDone());
         assertFalse(future2.isCompletedExceptionally());
     }


### PR DESCRIPTION
New changes:

1. Objects owned by the background thread are not instantiated until the background thread runs (via `Supplier`)
2. Introduced `ConsumerTestBuilder` to reduce a lot of inconsistency in the way the objects were built up for tests
3. Ensuring resources are properly using `Closeable` and using `IdempotentCloser` to ensure they're only closed once

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
