### PR TITLE
KAFKA-15115 - Reset positions implementation

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetFetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetFetcher.java
@@ -24,7 +24,6 @@ import org.apache.kafka.clients.StaleMetadataException;
 import org.apache.kafka.clients.consumer.LogTruncationException;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
-import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.clients.consumer.internals.OffsetFetcherUtils.ListOffsetData;
 import org.apache.kafka.clients.consumer.internals.OffsetFetcherUtils.ListOffsetResult;
 import org.apache.kafka.clients.consumer.internals.OffsetsForLeaderEpochClient.OffsetForEpochResult;
@@ -34,12 +33,9 @@ import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.RetriableException;
 import org.apache.kafka.common.errors.TimeoutException;
-import org.apache.kafka.common.message.ApiVersionsResponseData.ApiVersion;
 import org.apache.kafka.common.message.ListOffsetsRequestData.ListOffsetsPartition;
-import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.requests.ListOffsetsRequest;
 import org.apache.kafka.common.requests.ListOffsetsResponse;
-import org.apache.kafka.common.requests.OffsetsForLeaderEpochRequest;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Timer;
@@ -54,9 +50,10 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+
+import static org.apache.kafka.clients.consumer.internals.OffsetFetcherUtils.hasUsableOffsetForLeaderEpochVersion;
 
 /**
  * {@link OffsetFetcher} is responsible for fetching the {@link OffsetAndTimestamp offsets} for
@@ -73,7 +70,6 @@ public class OffsetFetcher {
     private final long retryBackoffMs;
     private final long requestTimeoutMs;
     private final IsolationLevel isolationLevel;
-    private final AtomicReference<RuntimeException> cachedListOffsetsException = new AtomicReference<>();
     private final OffsetsForLeaderEpochClient offsetsForLeaderEpochClient;
     private final ApiVersions apiVersions;
     private final OffsetFetcherUtils offsetFetcherUtils;
@@ -98,16 +94,7 @@ public class OffsetFetcher {
         this.apiVersions = apiVersions;
         this.offsetsForLeaderEpochClient = new OffsetsForLeaderEpochClient(client, logContext);
         this.offsetFetcherUtils = new OffsetFetcherUtils(logContext, metadata, subscriptions,
-            time, apiVersions);
-    }
-
-    private OffsetResetStrategy timestampToOffsetResetStrategy(long timestamp) {
-        if (timestamp == ListOffsetsRequest.EARLIEST_TIMESTAMP)
-            return OffsetResetStrategy.EARLIEST;
-        else if (timestamp == ListOffsetsRequest.LATEST_TIMESTAMP)
-            return OffsetResetStrategy.LATEST;
-        else
-            return null;
+            time, retryBackoffMs, apiVersions);
     }
 
     /**
@@ -117,11 +104,6 @@ public class OffsetFetcher {
      *                                                                         and one or more partitions aren't awaiting a seekToBeginning() or seekToEnd().
      */
     public void resetPositionsIfNeeded() {
-        // Raise exception from previous offset fetch if there is one
-        RuntimeException exception = cachedListOffsetsException.getAndSet(null);
-        if (exception != null)
-            throw exception;
-
         Map<TopicPartition, Long> offsetResetTimestamps =
             offsetFetcherUtils.getOffsetResetTimestamp();
 
@@ -230,16 +212,6 @@ public class OffsetFetcher {
         }
     }
 
-    // Visible for testing
-    void resetPositionIfNeeded(TopicPartition partition, OffsetResetStrategy requestedResetStrategy, ListOffsetData offsetData) {
-        FetchPosition position = new FetchPosition(
-                offsetData.offset,
-                Optional.empty(), // This will ensure we skip validation
-                metadata.currentLeader(partition));
-        offsetData.leaderEpoch.ifPresent(epoch -> metadata.updateLastSeenEpochIfNewer(partition, epoch));
-        subscriptions.maybeSeekUnvalidated(partition, position, requestedResetStrategy);
-    }
-
     private void resetPositionsAsync(Map<TopicPartition, Long> partitionResetTimestamps) {
         Map<Node, Map<TopicPartition, ListOffsetsPartition>> timestampsToSearchByNode =
                 groupListOffsetRequests(partitionResetTimestamps, new HashSet<>());
@@ -252,37 +224,15 @@ public class OffsetFetcher {
             future.addListener(new RequestFutureListener<ListOffsetResult>() {
                 @Override
                 public void onSuccess(ListOffsetResult result) {
-                    if (!result.partitionsToRetry.isEmpty()) {
-                        subscriptions.requestFailed(result.partitionsToRetry, time.milliseconds() + retryBackoffMs);
-                        metadata.requestUpdate();
-                    }
-
-                    for (Map.Entry<TopicPartition, ListOffsetData> fetchedOffset : result.fetchedOffsets.entrySet()) {
-                        TopicPartition partition = fetchedOffset.getKey();
-                        ListOffsetData offsetData = fetchedOffset.getValue();
-                        ListOffsetsPartition requestedReset = resetTimestamps.get(partition);
-                        resetPositionIfNeeded(partition, timestampToOffsetResetStrategy(requestedReset.timestamp()), offsetData);
-                    }
+                    offsetFetcherUtils.onSuccessfulRequestForResettingPositions(resetTimestamps, result);
                 }
 
                 @Override
                 public void onFailure(RuntimeException e) {
-                    subscriptions.requestFailed(resetTimestamps.keySet(), time.milliseconds() + retryBackoffMs);
-                    metadata.requestUpdate();
-
-                    if (!(e instanceof RetriableException) && !cachedListOffsetsException.compareAndSet(null, e))
-                        log.error("Discarding error in ListOffsetResponse because another error is pending", e);
+                    offsetFetcherUtils.onFailedRequestForResettingPositions(resetTimestamps, e);
                 }
             });
         }
-    }
-
-    static boolean hasUsableOffsetForLeaderEpochVersion(NodeApiVersions nodeApiVersions) {
-        ApiVersion apiVersion = nodeApiVersions.apiVersion(ApiKeys.OFFSET_FOR_LEADER_EPOCH);
-        if (apiVersion == null)
-            return false;
-
-        return OffsetsForLeaderEpochRequest.supportsTopicPermission(apiVersion.maxVersion());
     }
 
     /**
@@ -295,7 +245,7 @@ public class OffsetFetcher {
      */
     private void validatePositionsAsync(Map<TopicPartition, FetchPosition> partitionsToValidate) {
         final Map<Node, Map<TopicPartition, FetchPosition>> regrouped =
-                regroupFetchPositionsByLeader(partitionsToValidate);
+                offsetFetcherUtils.regroupFetchPositionsByLeader(partitionsToValidate);
 
         long nextResetTimeMs = time.milliseconds() + requestTimeoutMs;
         regrouped.forEach((node, fetchPositions) -> {
@@ -518,8 +468,6 @@ public class OffsetFetcher {
         }
     }
 
-
-
     /**
      * If we have seen new metadata (as tracked by {@link org.apache.kafka.clients.Metadata#updateVersion()}), then
      * we should check that all the assignments have a valid position.
@@ -527,14 +475,4 @@ public class OffsetFetcher {
     public void validatePositionsOnMetadataChange() {
         offsetFetcherUtils.validatePositionsOnMetadataChange();
     }
-
-    private Map<Node, Map<TopicPartition, FetchPosition>> regroupFetchPositionsByLeader(
-            Map<TopicPartition, FetchPosition> partitionMap) {
-        return partitionMap.entrySet()
-                .stream()
-                .filter(entry -> entry.getValue().currentLeader.leader.isPresent())
-                .collect(Collectors.groupingBy(entry -> entry.getValue().currentLeader.leader.get(),
-                        Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
-    }
-
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetFetcherUtils.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetFetcherUtils.java
@@ -17,16 +17,22 @@
 package org.apache.kafka.clients.consumer.internals;
 
 import org.apache.kafka.clients.ApiVersions;
+import org.apache.kafka.clients.NodeApiVersions;
 import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
 import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.common.IsolationLevel;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.RetriableException;
 import org.apache.kafka.common.errors.TopicAuthorizationException;
+import org.apache.kafka.common.message.ApiVersionsResponseData;
+import org.apache.kafka.common.message.ListOffsetsRequestData;
 import org.apache.kafka.common.message.ListOffsetsResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.ListOffsetsRequest;
 import org.apache.kafka.common.requests.ListOffsetsResponse;
+import org.apache.kafka.common.requests.OffsetsForLeaderEpochRequest;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 import org.slf4j.Logger;
@@ -49,21 +55,25 @@ class OffsetFetcherUtils {
     private final ConsumerMetadata metadata;
     private final SubscriptionState subscriptionState;
     private final Time time;
+    private final long retryBackoffMs;
     private final ApiVersions apiVersions;
     private final Logger log;
 
     private final AtomicReference<RuntimeException> cachedOffsetForLeaderException = new AtomicReference<>();
+    private final AtomicReference<RuntimeException> cachedListOffsetsException = new AtomicReference<>();
     private final AtomicInteger metadataUpdateVersion = new AtomicInteger(-1);
 
     OffsetFetcherUtils(LogContext logContext,
                        ConsumerMetadata metadata,
                        SubscriptionState subscriptionState,
                        Time time,
+                       long retryBackoffMs,
                        ApiVersions apiVersions) {
         this.log = logContext.logger(getClass());
         this.metadata = metadata;
         this.subscriptionState = subscriptionState;
         this.time = time;
+        this.retryBackoffMs = retryBackoffMs;
         this.apiVersions = apiVersions;
     }
 
@@ -198,6 +208,11 @@ class OffsetFetcherUtils {
     }
 
     Map<TopicPartition, Long> getOffsetResetTimestamp() {
+        // Raise exception from previous offset fetch if there is one
+        RuntimeException exception = cachedListOffsetsException.getAndSet(null);
+        if (exception != null)
+            throw exception;
+
         Set<TopicPartition> partitions = subscriptionState.partitionsNeedingReset(time.milliseconds());
         final Map<TopicPartition, Long> offsetResetTimestamps = new HashMap<>();
         for (final TopicPartition partition : partitions) {
@@ -259,6 +274,73 @@ class OffsetFetcherUtils {
                 }
             }
         }
+    }
+
+    OffsetResetStrategy timestampToOffsetResetStrategy(long timestamp) {
+        if (timestamp == ListOffsetsRequest.EARLIEST_TIMESTAMP)
+            return OffsetResetStrategy.EARLIEST;
+        else if (timestamp == ListOffsetsRequest.LATEST_TIMESTAMP)
+            return OffsetResetStrategy.LATEST;
+        else
+            return null;
+    }
+
+    void onSuccessfulRequestForResettingPositions(
+            final Map<TopicPartition, ListOffsetsRequestData.ListOffsetsPartition> resetTimestamps,
+            final ListOffsetResult result) {
+        if (!result.partitionsToRetry.isEmpty()) {
+            subscriptionState.requestFailed(result.partitionsToRetry, time.milliseconds() + retryBackoffMs);
+            metadata.requestUpdate();
+        }
+
+        for (Map.Entry<TopicPartition, ListOffsetData> fetchedOffset : result.fetchedOffsets.entrySet()) {
+            TopicPartition partition = fetchedOffset.getKey();
+            ListOffsetData offsetData = fetchedOffset.getValue();
+            ListOffsetsRequestData.ListOffsetsPartition requestedReset = resetTimestamps.get(partition);
+            resetPositionIfNeeded(
+                    partition,
+                    timestampToOffsetResetStrategy(requestedReset.timestamp()),
+                    offsetData);
+        }
+    }
+
+    void onFailedRequestForResettingPositions(
+            final Map<TopicPartition, ListOffsetsRequestData.ListOffsetsPartition> resetTimestamps,
+            final RuntimeException error) {
+        subscriptionState.requestFailed(resetTimestamps.keySet(), time.milliseconds() + retryBackoffMs);
+        metadata.requestUpdate();
+
+        if (!(error instanceof RetriableException) && !cachedListOffsetsException.compareAndSet(null,
+                error))
+            log.error("Discarding error in ListOffsetResponse because another error is pending", error);
+    }
+
+    // Visible for testing
+    void resetPositionIfNeeded(TopicPartition partition, OffsetResetStrategy requestedResetStrategy,
+                               ListOffsetData offsetData) {
+        SubscriptionState.FetchPosition position = new SubscriptionState.FetchPosition(
+                offsetData.offset,
+                Optional.empty(), // This will ensure we skip validation
+                metadata.currentLeader(partition));
+        offsetData.leaderEpoch.ifPresent(epoch -> metadata.updateLastSeenEpochIfNewer(partition, epoch));
+        subscriptionState.maybeSeekUnvalidated(partition, position, requestedResetStrategy);
+    }
+
+    Map<Node, Map<TopicPartition, SubscriptionState.FetchPosition>> regroupFetchPositionsByLeader(
+            Map<TopicPartition, SubscriptionState.FetchPosition> partitionMap) {
+        return partitionMap.entrySet()
+                .stream()
+                .filter(entry -> entry.getValue().currentLeader.leader.isPresent())
+                .collect(Collectors.groupingBy(entry -> entry.getValue().currentLeader.leader.get(),
+                        Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+    }
+
+    static boolean hasUsableOffsetForLeaderEpochVersion(NodeApiVersions nodeApiVersions) {
+        ApiVersionsResponseData.ApiVersion apiVersion = nodeApiVersions.apiVersion(ApiKeys.OFFSET_FOR_LEADER_EPOCH);
+        if (apiVersion == null)
+            return false;
+
+        return OffsetsForLeaderEpochRequest.supportsTopicPermission(apiVersion.maxVersion());
     }
 
     static class ListOffsetResult {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestManagers.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestManagers.java
@@ -122,10 +122,14 @@ public class RequestManagers<K, V> implements Closeable {
                 final ErrorEventHandler errorEventHandler = new ErrorEventHandler(backgroundEventQueue);
                 final IsolationLevel isolationLevel = getConfiguredIsolationLevel(config);
                 final FetchConfig<K, V> fetchConfig = createFetchConfig(config);
+                final long retryBackoffMs = config.getLong(ConsumerConfig.RETRY_BACKOFF_MS_CONFIG);
+                final long requestTimeoutMs = config.getLong(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG);
                 final ListOffsetsRequestManager listOffsets = new ListOffsetsRequestManager(subscriptions,
                         metadata,
                         isolationLevel,
                         time,
+                        retryBackoffMs,
+                        requestTimeoutMs,
                         apiVersions,
                         logContext);
                 final TopicMetadataRequestManager topicMetadata = new TopicMetadataRequestManager(logContext, config);
@@ -141,7 +145,6 @@ public class RequestManagers<K, V> implements Closeable {
                 CommitRequestManager commit = null;
 
                 if (groupRebalanceConfig != null && groupRebalanceConfig.groupId != null) {
-                    final long retryBackoffMs = config.getLong(ConsumerConfig.RETRY_BACKOFF_MS_CONFIG);
                     final GroupState groupState = new GroupState(groupRebalanceConfig);
                     coordinator = new CoordinatorRequestManager(time,
                             logContext,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/SubscriptionState.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/SubscriptionState.java
@@ -47,7 +47,7 @@ import java.util.function.LongSupplier;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
-import static org.apache.kafka.clients.consumer.internals.OffsetFetcher.hasUsableOffsetForLeaderEpochVersion;
+import static org.apache.kafka.clients.consumer.internals.OffsetFetcherUtils.hasUsableOffsetForLeaderEpochVersion;
 import static org.apache.kafka.common.requests.OffsetsForLeaderEpochResponse.UNDEFINED_EPOCH;
 import static org.apache.kafka.common.requests.OffsetsForLeaderEpochResponse.UNDEFINED_EPOCH_OFFSET;
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
@@ -85,6 +85,8 @@ public class ApplicationEventProcessor<K, V> {
                 return process((ListOffsetsApplicationEvent) event);
             case FETCH:
                 return process((FetchEvent<K, V>) event);
+            case RESET_POSITIONS:
+                return processResetPositionsEvent();
         }
         return false;
     }
@@ -161,6 +163,11 @@ public class ApplicationEventProcessor<K, V> {
                 requestManagers.listOffsetsRequestManager.fetchOffsets(event.timestampsToSearch,
                         event.requireTimestamps);
         event.chain(future);
+        return true;
+    }
+
+    private boolean processResetPositionsEvent() {
+        requestManagers.listOffsetsRequestManager.resetPositionsIfNeeded();
         return true;
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ResetPositionsApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ResetPositionsApplicationEvent.java
@@ -14,27 +14,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.kafka.clients.consumer.internals.events;
 
-import java.util.Objects;
+import org.apache.kafka.common.TopicPartition;
+
+import java.util.Map;
 
 /**
- * This is the abstract definition of the events created by the KafkaConsumer API
+ * Event for resetting offsets for all assigned partitions that require it.
  */
-public abstract class ApplicationEvent {
+public class ResetPositionsApplicationEvent extends CompletableApplicationEvent<Map<TopicPartition, Long>> {
 
-    public enum Type {
-        NOOP, COMMIT, POLL, FETCH, FETCH_COMMITTED_OFFSET, METADATA_UPDATE, UNSUBSCRIBE,
-        LIST_OFFSETS, TOPIC_METADATA, RESET_POSITIONS
-    }
-
-    protected final Type type;
-
-    protected ApplicationEvent(Type type) {
-        this.type = Objects.requireNonNull(type);
-    }
-
-    public Type type() {
-        return type;
+    public ResetPositionsApplicationEvent() {
+        super(Type.RESET_POSITIONS);
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerTestBuilder.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerTestBuilder.java
@@ -93,9 +93,12 @@ public class ConsumerTestBuilder implements Closeable {
         properties.put(KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         properties.put(VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         properties.put(CommonClientConfigs.RETRY_BACKOFF_MS_CONFIG, RETRY_BACKOFF_MS);
+        properties.put(CommonClientConfigs.REQUEST_TIMEOUT_MS_CONFIG, REQUEST_TIMEOUT_MS);
 
         this.config = new ConsumerConfig(properties);
         IsolationLevel isolationLevel = getConfiguredIsolationLevel(config);
+        final long retryBackoffMs = config.getLong(ConsumerConfig.RETRY_BACKOFF_MS_CONFIG);
+        final long requestTimeoutMs = config.getInt(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG);
         Metrics metrics = createMetrics(config, time);
 
         this.subscriptions = createSubscriptionState(config, logContext);
@@ -112,6 +115,8 @@ public class ConsumerTestBuilder implements Closeable {
                 metadata,
                 isolationLevel,
                 time,
+                retryBackoffMs,
+                requestTimeoutMs,
                 apiVersions,
                 logContext));
         this.topicMetadataRequestManager = spy(new TopicMetadataRequestManager(logContext, config));

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThreadTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThreadTest.java
@@ -22,6 +22,7 @@ import org.apache.kafka.clients.consumer.internals.events.CommitApplicationEvent
 import org.apache.kafka.clients.consumer.internals.events.ListOffsetsApplicationEvent;
 import org.apache.kafka.clients.consumer.internals.events.MetadataUpdateApplicationEvent;
 import org.apache.kafka.clients.consumer.internals.events.NoopApplicationEvent;
+import org.apache.kafka.clients.consumer.internals.events.ResetPositionsApplicationEvent;
 import org.apache.kafka.clients.consumer.internals.events.TopicMetadataApplicationEvent;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.message.FindCoordinatorRequestData;
@@ -142,6 +143,16 @@ public class DefaultBackgroundThreadTest {
         this.applicationEventsQueue.add(e);
         backgroundThread.runOnce();
         verify(applicationEventProcessor).process(any(ListOffsetsApplicationEvent.class));
+        assertTrue(applicationEventsQueue.isEmpty());
+        backgroundThread.close();
+    }
+
+    @Test
+    public void testResetPositionsEventIsProcessed() {
+        ApplicationEvent e = new ResetPositionsApplicationEvent();
+        this.applicationEventsQueue.add(e);
+        backgroundThread.runOnce();
+        verify(applicationEventProcessor).process(any(ResetPositionsApplicationEvent.class));
         assertTrue(applicationEventsQueue.isEmpty());
         backgroundThread.close();
     }


### PR DESCRIPTION
This includes the a new event for resetting positions and its processing logic in the ListOffsetsRequestManager given that it ultimately performs a LIST_OFFSETS requests for the partitions needing reset.

It includes some basic unit testing for this will be followed by another PR adding more. 

It also includes a minor refactoring in the existing OffsetFetcher and OffsetFetcherUtils, extracting more reusable functionality (no changes in logic there)