### PR TITLE
KAFKA-15188: Implement more of the remaining PrototypeAsyncConsumer APIs

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThread.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThread.java
@@ -114,15 +114,13 @@ public class DefaultBackgroundThread<K, V> extends KafkaThread implements Closea
      * 3. Poll the networkClient to send and retrieve the response.
      */
     void runOnce() {
-        if (!applicationEventQueue.isEmpty()) {
-            LinkedList<ApplicationEvent> res = new LinkedList<>();
-            this.applicationEventQueue.drainTo(res);
+        LinkedList<ApplicationEvent> events = new LinkedList<>();
+        applicationEventQueue.drainTo(events);
 
-            for (ApplicationEvent event : res) {
-                log.debug("Consuming application event: {}", event);
-                Objects.requireNonNull(event);
-                applicationEventProcessor.process(event);
-            }
+        for (ApplicationEvent event : events) {
+            log.debug("Consuming application event: {}", event);
+            Objects.requireNonNull(event);
+            applicationEventProcessor.process(event);
         }
 
         final long currentTimeMs = time.milliseconds();

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultEventHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultEventHandler.java
@@ -24,6 +24,7 @@ import org.apache.kafka.clients.consumer.internals.events.EventHandler;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.Timer;
 import org.slf4j.Logger;
 
 import java.time.Duration;
@@ -83,11 +84,11 @@ public class DefaultEventHandler<K, V> implements EventHandler {
     }
 
     @Override
-    public <T> T addAndGet(final CompletableApplicationEvent<T> event, final Duration timeout) {
+    public <T> T addAndGet(final CompletableApplicationEvent<T> event, final Timer timer) {
         Objects.requireNonNull(event, "CompletableApplicationEvent provided to addAndGet must be non-null");
-        Objects.requireNonNull(timeout, "Duration provided to addAndGet must be non-null");
+        Objects.requireNonNull(timer, "Timer provided to addAndGet must be non-null");
         add(event);
-        return event.get(time.timer(timeout));
+        return event.get(timer);
     }
 
     public void close(final Duration timeout) {
@@ -110,6 +111,5 @@ public class DefaultEventHandler<K, V> implements EventHandler {
                     }
                 },
                 () -> log.info("The default consumer event handler was already closed"));
-
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultEventHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultEventHandler.java
@@ -40,9 +40,7 @@ import java.util.function.Supplier;
 public class DefaultEventHandler<K, V> implements EventHandler {
 
     private final Logger log;
-    private final Time time;
     private final BlockingQueue<ApplicationEvent> applicationEventQueue;
-    private final BlockingQueue<BackgroundEvent> backgroundEventQueue;
     private final DefaultBackgroundThread<K, V> backgroundThread;
     private final IdempotentCloser closer = new IdempotentCloser();
 
@@ -54,9 +52,7 @@ public class DefaultEventHandler<K, V> implements EventHandler {
                                final Supplier<NetworkClientDelegate> networkClientDelegateSupplier,
                                final Supplier<RequestManagers<K, V>> requestManagersSupplier) {
         this.log = logContext.logger(DefaultEventHandler.class);
-        this.time = time;
         this.applicationEventQueue = applicationEventQueue;
-        this.backgroundEventQueue = backgroundEventQueue;
         this.backgroundThread = new DefaultBackgroundThread<>(time,
                 logContext,
                 applicationEventQueue,
@@ -64,16 +60,6 @@ public class DefaultEventHandler<K, V> implements EventHandler {
                 networkClientDelegateSupplier,
                 requestManagersSupplier);
         this.backgroundThread.start();
-    }
-
-    @Override
-    public Optional<BackgroundEvent> poll() {
-        return Optional.ofNullable(backgroundEventQueue.poll());
-    }
-
-    @Override
-    public boolean isEmpty() {
-        return backgroundEventQueue.isEmpty();
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ErrorEventHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ErrorEventHandler.java
@@ -28,7 +28,11 @@ public class ErrorEventHandler {
         this.backgroundEventQueue = backgroundEventQueue;
     }
 
-    public void handle(Throwable e) {
+    public void handle(RuntimeException e) {
         backgroundEventQueue.add(new ErrorBackgroundEvent(e));
+    }
+
+    public void handle(Throwable e) {
+        handle(new RuntimeException(e));
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumer.java
@@ -18,17 +18,21 @@ package org.apache.kafka.clients.consumer.internals;
 
 import org.apache.kafka.clients.ApiVersions;
 import org.apache.kafka.clients.ClientUtils;
+import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.GroupRebalanceConfig;
+import org.apache.kafka.clients.Metadata;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
 import org.apache.kafka.clients.consumer.ConsumerInterceptor;
+import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.NoOffsetForPartitionException;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
 import org.apache.kafka.clients.consumer.OffsetCommitCallback;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.clients.consumer.internals.events.ApplicationEvent;
 import org.apache.kafka.clients.consumer.internals.events.ApplicationEventProcessor;
 import org.apache.kafka.clients.consumer.internals.events.BackgroundEvent;
@@ -41,6 +45,9 @@ import org.apache.kafka.clients.consumer.internals.events.ResetPositionsApplicat
 import org.apache.kafka.clients.consumer.internals.events.UnsubscribeApplicationEvent;
 import org.apache.kafka.clients.consumer.internals.events.FetchEvent;
 import org.apache.kafka.clients.consumer.internals.events.ValidatePositionsApplicationEvent;
+import org.apache.kafka.clients.consumer.internals.events.TopicMetadataApplicationEvent;
+import org.apache.kafka.common.Cluster;
+import org.apache.kafka.common.IsolationLevel;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
@@ -49,14 +56,17 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.errors.InterruptException;
 import org.apache.kafka.common.errors.InvalidGroupIdException;
+import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.internals.ClusterResourceListeners;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.requests.ListOffsetsRequest;
 import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.utils.AppInfoParser;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Timer;
 import org.slf4j.Logger;
+import org.slf4j.event.Level;
 
 import java.net.InetSocketAddress;
 import java.time.Duration;
@@ -67,6 +77,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Properties;
@@ -74,10 +85,7 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -87,16 +95,20 @@ import java.util.stream.Collectors;
 import static java.util.Objects.requireNonNull;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.clients.consumer.internals.Utils.CONSUMER_JMX_PREFIX;
+import static org.apache.kafka.clients.consumer.internals.Utils.CONSUMER_METRIC_GROUP_PREFIX;
 import static org.apache.kafka.clients.consumer.internals.Utils.createFetchConfig;
 import static org.apache.kafka.clients.consumer.internals.Utils.createFetchMetricsManager;
 import static org.apache.kafka.clients.consumer.internals.Utils.createLogContext;
 import static org.apache.kafka.clients.consumer.internals.Utils.createMetrics;
 import static org.apache.kafka.clients.consumer.internals.Utils.createSubscriptionState;
 import static org.apache.kafka.clients.consumer.internals.Utils.getConfiguredConsumerInterceptors;
+import static org.apache.kafka.clients.consumer.internals.Utils.getConfiguredIsolationLevel;
 import static org.apache.kafka.common.utils.Utils.closeQuietly;
 import static org.apache.kafka.common.utils.Utils.isBlank;
 import static org.apache.kafka.common.utils.Utils.join;
 import static org.apache.kafka.common.utils.Utils.propsToMap;
+import static org.apache.kafka.common.utils.Utils.swallow;
 
 /**
  * This prototype consumer uses the EventHandler to process application
@@ -107,17 +119,30 @@ import static org.apache.kafka.common.utils.Utils.propsToMap;
 public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
     static final long DEFAULT_CLOSE_TIMEOUT_MS = 30 * 1000;
 
-    private final LogContext logContext;
-    private final EventHandler eventHandler;
-    private final Time time;
+    private final Metrics metrics;
+    private final KafkaConsumerMetrics kafkaConsumerMetrics;
+
+    private Logger log;
+    private final String clientId;
     private final Optional<String> groupId;
-    private final Logger log;
-    private final SubscriptionState subscriptions;
-    private final long defaultApiTimeoutMs;
-    private final ConsumerMetadata metadata;
-    private final ConsumerInterceptors<K, V> interceptors;
+    private final EventHandler eventHandler;
+    private final Deserializers<K, V> deserializers;
     private final FetchBuffer<K, V> fetchBuffer;
     private final FetchCollector<K, V> fetchCollector;
+    private final ConsumerInterceptors<K, V> interceptors;
+    private final IsolationLevel isolationLevel;
+
+    private final Time time;
+    private final SubscriptionState subscriptions;
+    private final ConsumerMetadata metadata;
+    private final long retryBackoffMs;
+    private final long requestTimeoutMs;
+    private final long defaultApiTimeoutMs;
+    private volatile boolean closed = false;
+    private final List<ConsumerPartitionAssignor> assignors;
+
+    // to keep from repeatedly scanning subscriptions in poll(), cache the result during metadata updates
+    private boolean cachedSubscriptionHasAllFetchPositions;
 
     public PrototypeAsyncConsumer(final Properties properties,
                                   final Deserializer<K> keyDeserializer,
@@ -142,92 +167,142 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
                                   final ConsumerConfig config,
                                   final Deserializer<K> keyDeserializer,
                                   final Deserializer<V> valueDeserializer) {
-        this.time = time;
-        GroupRebalanceConfig groupRebalanceConfig = new GroupRebalanceConfig(config,
-                GroupRebalanceConfig.ProtocolType.CONSUMER);
-        this.groupId = Optional.ofNullable(groupRebalanceConfig.groupId);
-        this.defaultApiTimeoutMs = config.getInt(ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG);
-        this.logContext = createLogContext(config, groupRebalanceConfig);
-        this.log = logContext.logger(getClass());
-        Deserializers<K, V> deserializers = new Deserializers<>(config, keyDeserializer, valueDeserializer);
-        this.subscriptions = createSubscriptionState(config, logContext);
-        Metrics metrics = createMetrics(config, time);
-        List<ConsumerInterceptor<K, V>> interceptorList = getConfiguredConsumerInterceptors(config);
-        this.interceptors = new ConsumerInterceptors<>(interceptorList);
-        ClusterResourceListeners clusterResourceListeners = ClientUtils.configureClusterResourceListeners(metrics.reporters(),
-                interceptorList,
-                Arrays.asList(deserializers.keyDeserializer, deserializers.valueDeserializer));
-        this.metadata = new ConsumerMetadata(config, subscriptions, logContext, clusterResourceListeners);
-        // Bootstrap the metadata with the bootstrap server IP address, which will be used once for the subsequent
-        // metadata refresh once the background thread has started up.
-        final List<InetSocketAddress> addresses = ClientUtils.parseAndValidateAddresses(config);
-        metadata.bootstrap(addresses);
+        try {
+            GroupRebalanceConfig groupRebalanceConfig = new GroupRebalanceConfig(config,
+                    GroupRebalanceConfig.ProtocolType.CONSUMER);
 
-        final BlockingQueue<ApplicationEvent> applicationEventQueue = new LinkedBlockingQueue<>();
-        final BlockingQueue<BackgroundEvent> backgroundEventQueue = new LinkedBlockingQueue<>();
+            this.groupId = Optional.ofNullable(groupRebalanceConfig.groupId);
+            this.clientId = config.getString(CommonClientConfigs.CLIENT_ID_CONFIG);
+            LogContext logContext = createLogContext(config, groupRebalanceConfig);
+            this.log = logContext.logger(getClass());
+            groupId.ifPresent(groupIdStr -> {
+                if (groupIdStr.isEmpty()) {
+                    log.warn("Support for using the empty group id by consumers is deprecated and will be removed in the next major release.");
+                }
+            });
 
-        FetchMetricsManager fetchMetricsManager = createFetchMetricsManager(metrics);
-        final Supplier<NetworkClientDelegate> networkClientDelegateSupplier = NetworkClientDelegate.supplier(time,
-                logContext,
-                metadata,
-                config,
-                new ApiVersions(),
-                metrics,
-                fetchMetricsManager);
-        final Supplier<RequestManagers<String, String>> requestManagersSupplier = RequestManagers.supplier(time,
-                logContext,
-                backgroundEventQueue,
-                metadata,
-                subscriptions,
-                config,
-                groupRebalanceConfig,
-                new ApiVersions(),
-                fetchMetricsManager,
-                networkClientDelegateSupplier);
-        final Supplier<ApplicationEventProcessor<String, String>> applicationEventProcessorSupplier = ApplicationEventProcessor.supplier(logContext,
-                metadata,
-                backgroundEventQueue,
-                requestManagersSupplier);
-        this.eventHandler = new DefaultEventHandler<>(time,
-                logContext,
-                applicationEventQueue,
-                backgroundEventQueue,
-                applicationEventProcessorSupplier,
-                networkClientDelegateSupplier,
-                requestManagersSupplier);
+            log.debug("Initializing the Kafka consumer");
+            this.requestTimeoutMs = config.getInt(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG);
+            this.defaultApiTimeoutMs = config.getInt(ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG);
+            this.time = time;
+            this.metrics = createMetrics(config, time);
+            this.retryBackoffMs = config.getLong(ConsumerConfig.RETRY_BACKOFF_MS_CONFIG);
 
-        // These are specific to the foreground thread
-        FetchConfig<K, V> fetchConfig = createFetchConfig(config, deserializers);
-        this.fetchBuffer = new FetchBuffer<>(logContext);
-        this.fetchCollector = new FetchCollector<>(logContext,
-                metadata,
-                subscriptions,
-                fetchConfig,
-                fetchMetricsManager,
-                time);
+            List<ConsumerInterceptor<K, V>> interceptorList = getConfiguredConsumerInterceptors(config);
+            this.interceptors = new ConsumerInterceptors<>(interceptorList);
+            this.deserializers = new Deserializers<>(config, keyDeserializer, valueDeserializer);
+            this.subscriptions = createSubscriptionState(config, logContext);
+            ClusterResourceListeners clusterResourceListeners = ClientUtils.configureClusterResourceListeners(metrics.reporters(),
+                    interceptorList,
+                    Arrays.asList(deserializers.keyDeserializer, deserializers.valueDeserializer));
+            this.metadata = new ConsumerMetadata(config, subscriptions, logContext, clusterResourceListeners);
+            final List<InetSocketAddress> addresses = ClientUtils.parseAndValidateAddresses(config);
+            metadata.bootstrap(addresses);
+
+            FetchMetricsManager fetchMetricsManager = createFetchMetricsManager(metrics);
+            this.isolationLevel = getConfiguredIsolationLevel(config);
+
+            ApiVersions apiVersions = new ApiVersions();
+            final BlockingQueue<ApplicationEvent> applicationEventQueue = new LinkedBlockingQueue<>();
+            final BlockingQueue<BackgroundEvent> backgroundEventQueue = new LinkedBlockingQueue<>();
+            final Supplier<NetworkClientDelegate> networkClientDelegateSupplier = NetworkClientDelegate.supplier(time,
+                    logContext,
+                    metadata,
+                    config,
+                    apiVersions,
+                    metrics,
+                    fetchMetricsManager);
+            final Supplier<RequestManagers<String, String>> requestManagersSupplier = RequestManagers.supplier(time,
+                    logContext,
+                    backgroundEventQueue,
+                    metadata,
+                    subscriptions,
+                    config,
+                    groupRebalanceConfig,
+                    apiVersions,
+                    fetchMetricsManager,
+                    networkClientDelegateSupplier);
+            final Supplier<ApplicationEventProcessor<String, String>> applicationEventProcessorSupplier = ApplicationEventProcessor.supplier(logContext,
+                    metadata,
+                    backgroundEventQueue,
+                    requestManagersSupplier);
+            this.eventHandler = new DefaultEventHandler<>(time,
+                    logContext,
+                    applicationEventQueue,
+                    backgroundEventQueue,
+                    applicationEventProcessorSupplier,
+                    networkClientDelegateSupplier,
+                    requestManagersSupplier);
+            this.assignors = ConsumerPartitionAssignor.getAssignorInstances(
+                    config.getList(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG),
+                    config.originals(Collections.singletonMap(ConsumerConfig.CLIENT_ID_CONFIG, clientId))
+            );
+
+            // no coordinator will be constructed for the default (null) group id
+            if (!groupId.isPresent()) {
+                config.ignore(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG);
+                //config.ignore(ConsumerConfig.THROW_ON_FETCH_STABLE_OFFSET_UNSUPPORTED);
+            }
+            // These are specific to the foreground thread
+            FetchConfig<K, V> fetchConfig = createFetchConfig(config, deserializers);
+            this.fetchBuffer = new FetchBuffer<>(logContext);
+            this.fetchCollector = new FetchCollector<>(logContext,
+                    metadata,
+                    subscriptions,
+                    fetchConfig,
+                    fetchMetricsManager,
+                    time);
+
+            this.kafkaConsumerMetrics = new KafkaConsumerMetrics(metrics, CONSUMER_METRIC_GROUP_PREFIX);
+
+            config.logUnused();
+            AppInfoParser.registerAppInfo(CONSUMER_JMX_PREFIX, clientId, metrics, time.milliseconds());
+            log.debug("Kafka consumer initialized");
+        } catch (Throwable t) {
+            // call close methods if internal objects are already constructed; this is to prevent resource leak. see KAFKA-2121
+            // we do not need to call `close` at all when `log` is null, which means no internal objects were initialized.
+            if (this.log != null) {
+                close(Duration.ZERO, true);
+            }
+            // now propagate the exception
+            throw new KafkaException("Failed to construct kafka consumer", t);
+        }
     }
 
     public PrototypeAsyncConsumer(LogContext logContext,
+                                  String clientId,
+                                  Deserializers<K, V> deserializers,
+                                  FetchBuffer<K, V> fetchBuffer,
+                                  FetchCollector<K, V> fetchCollector,
+                                  ConsumerInterceptors<K, V> interceptors,
                                   Time time,
                                   EventHandler eventHandler,
-                                  Optional<String> groupId,
+                                  Metrics metrics,
                                   SubscriptionState subscriptions,
-                                  long defaultApiTimeoutMs,
                                   ConsumerMetadata metadata,
-                                  ConsumerInterceptors<K, V> interceptors,
-                                  FetchBuffer<K, V> fetchBuffer,
-                                  FetchCollector<K, V> fetchCollector) {
-        this.logContext = logContext;
+                                  long retryBackoffMs,
+                                  long requestTimeoutMs,
+                                  int defaultApiTimeoutMs,
+                                  List<ConsumerPartitionAssignor> assignors,
+                                  String groupId) {
         this.log = logContext.logger(getClass());
-        this.subscriptions = subscriptions;
-        this.time = time;
-        this.groupId = groupId;
-        this.defaultApiTimeoutMs = defaultApiTimeoutMs;
-        this.eventHandler = eventHandler;
-        this.metadata = metadata;
-        this.interceptors = interceptors;
+        this.clientId = clientId;
+        this.deserializers = deserializers;
         this.fetchBuffer = fetchBuffer;
         this.fetchCollector = fetchCollector;
+        this.isolationLevel = IsolationLevel.READ_UNCOMMITTED;
+        this.interceptors = Objects.requireNonNull(interceptors);
+        this.time = time;
+        this.eventHandler = eventHandler;
+        this.metrics = metrics;
+        this.subscriptions = subscriptions;
+        this.metadata = metadata;
+        this.retryBackoffMs = retryBackoffMs;
+        this.requestTimeoutMs = requestTimeoutMs;
+        this.defaultApiTimeoutMs = defaultApiTimeoutMs;
+        this.assignors = assignors;
+        this.groupId = Optional.ofNullable(groupId);
+        this.kafkaConsumerMetrics = new KafkaConsumerMetrics(metrics, "consumer");
     }
 
     /**
@@ -242,46 +317,36 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
      */
     @Override
     public ConsumerRecords<K, V> poll(final Duration timeout) {
+        Timer timer = time.timer(timeout);
+
         try {
-            Timer timer = time.timer(timeout);
+            this.kafkaConsumerMetrics.recordPollStart(timer.currentTimeMs());
+
+            if (this.subscriptions.hasNoSubscriptionOrUserAssignment()) {
+                throw new IllegalStateException("Consumer is not subscribed to any topics or assigned any partitions");
+            }
 
             do {
-                if (!eventHandler.isEmpty()) {
-                    final Optional<BackgroundEvent> backgroundEvent = eventHandler.poll();
-                    // processEvent() may process 3 types of event:
-                    // 1. Errors
-                    // 2. Callback Invocation
-                    // 3. Fetch responses
-                    // Errors will be handled or rethrown.
-                    // Callback invocation will trigger callback function execution, which is blocking until completion.
-                    // Successful fetch responses will be added to the completedFetches in the fetcher, which will then
-                    // be processed in the collectFetches().
-                    backgroundEvent.ifPresent(event -> log.warn("Do something with this background event: {}", event));
-                }
+                updateAssignmentMetadataIfNeeded(timer);
+                final Fetch<K, V> fetch = pollForFetches(timer);
 
-                updateAssignmentMetadataIfNeeded();
-
-                // Create our event as a means to request the background thread to return any completed fetches.
-                // If there are any
-                Queue<CompletedFetch<K, V>> completedFetches = eventHandler.addAndGet(new FetchEvent<>(), timeout);
-
-                if (completedFetches != null && !completedFetches.isEmpty()) {
-                    fetchBuffer.addAll(completedFetches);
-                }
-
-                // The idea here is to have the background thread sending fetches autonomously, and the fetcher
-                // uses the poll loop to retrieve successful fetchResponse and process them on the polling thread.
-                final Fetch<K, V> fetch = fetchCollector.collectFetch(fetchBuffer);
                 if (!fetch.isEmpty()) {
+                    sendFetches();
+
+                    if (fetch.records().isEmpty()) {
+                        log.trace("Returning empty records from `poll()` "
+                                + "since the consumer's position has advanced for at least one topic partition");
+                    }
+
                     return this.interceptors.onConsume(new ConsumerRecords<>(fetch.records()));
                 }
                 // We will wait for retryBackoffMs
             } while (timer.notExpired());
-        } catch (final Exception e) {
-            throw new RuntimeException(e);
-        }
 
-        return ConsumerRecords.empty();
+            return ConsumerRecords.empty();
+        } finally {
+            this.kafkaConsumerMetrics.recordPollEnd(timer.currentTimeMs());
+        }
     }
 
     boolean updateAssignmentMetadataIfNeeded() {
@@ -365,44 +430,90 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
 
     @Override
     public void seek(TopicPartition partition, long offset) {
-        throw new KafkaException("method not implemented");
+        if (offset < 0)
+            throw new IllegalArgumentException("seek offset must not be a negative number");
+
+        log.info("Seeking to offset {} for partition {}", offset, partition);
+        SubscriptionState.FetchPosition newPosition = new SubscriptionState.FetchPosition(
+                offset,
+                Optional.empty(), // This will ensure we skip validation
+                this.metadata.currentLeader(partition));
+        this.subscriptions.seekUnvalidated(partition, newPosition);
     }
 
     @Override
     public void seek(TopicPartition partition, OffsetAndMetadata offsetAndMetadata) {
-        throw new KafkaException("method not implemented");
+        long offset = offsetAndMetadata.offset();
+        if (offset < 0) {
+            throw new IllegalArgumentException("seek offset must not be a negative number");
+        }
+
+        if (offsetAndMetadata.leaderEpoch().isPresent()) {
+            log.info("Seeking to offset {} for partition {} with epoch {}",
+                offset, partition, offsetAndMetadata.leaderEpoch().get());
+        } else {
+            log.info("Seeking to offset {} for partition {}", offset, partition);
+        }
+        Metadata.LeaderAndEpoch currentLeaderAndEpoch = this.metadata.currentLeader(partition);
+        SubscriptionState.FetchPosition newPosition = new SubscriptionState.FetchPosition(
+            offsetAndMetadata.offset(),
+            offsetAndMetadata.leaderEpoch(),
+            currentLeaderAndEpoch);
+        this.updateLastSeenEpochIfNewer(partition, offsetAndMetadata);
+        this.subscriptions.seekUnvalidated(partition, newPosition);
     }
 
     @Override
     public void seekToBeginning(Collection<TopicPartition> partitions) {
-        throw new KafkaException("method not implemented");
+        if (partitions == null)
+            throw new IllegalArgumentException("Partitions collection cannot be null");
+
+        Collection<TopicPartition> parts = partitions.size() == 0 ? this.subscriptions.assignedPartitions() : partitions;
+        subscriptions.requestOffsetReset(parts, OffsetResetStrategy.EARLIEST);
     }
 
     @Override
     public void seekToEnd(Collection<TopicPartition> partitions) {
-        throw new KafkaException("method not implemented");
+        if (partitions == null)
+            throw new IllegalArgumentException("Partitions collection cannot be null");
+
+        Collection<TopicPartition> parts = partitions.size() == 0 ? this.subscriptions.assignedPartitions() : partitions;
+        subscriptions.requestOffsetReset(parts, OffsetResetStrategy.LATEST);
     }
 
     @Override
     public long position(TopicPartition partition) {
-        throw new KafkaException("method not implemented");
+        return position(partition, Duration.ofMillis(defaultApiTimeoutMs));
     }
 
     @Override
     public long position(TopicPartition partition, Duration timeout) {
-        throw new KafkaException("method not implemented");
+        if (!this.subscriptions.isAssigned(partition))
+            throw new IllegalStateException("You can only check the position for partitions assigned to this consumer.");
+
+        Timer timer = time.timer(timeout);
+        do {
+            SubscriptionState.FetchPosition position = this.subscriptions.validPosition(partition);
+            if (position != null)
+                return position.offset;
+
+            updateFetchPositions(timer);
+        } while (timer.notExpired());
+
+        throw new TimeoutException("Timeout of " + timeout.toMillis() + "ms expired before the position " +
+                "for partition " + partition + " could be determined");
     }
 
     @Override
     @Deprecated
     public OffsetAndMetadata committed(TopicPartition partition) {
-        throw new KafkaException("method not implemented");
+        return committed(partition, Duration.ofMillis(defaultApiTimeoutMs));
     }
 
     @Override
     @Deprecated
     public OffsetAndMetadata committed(TopicPartition partition, Duration timeout) {
-        throw new KafkaException("method not implemented");
+        return committed(Collections.singleton(partition), timeout).get(partition);
     }
 
     @Override
@@ -413,12 +524,22 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
     @Override
     public Map<TopicPartition, OffsetAndMetadata> committed(final Set<TopicPartition> partitions,
                                                             final Duration timeout) {
-        maybeThrowInvalidGroupIdException();
-        if (partitions.isEmpty()) {
-            return new HashMap<>();
+        long start = time.nanoseconds();
+        try {
+            maybeThrowInvalidGroupIdException();
+            final Map<TopicPartition, OffsetAndMetadata> offsets;
+            offsets = eventHandler.addAndGet(new OffsetFetchApplicationEvent(partitions), time.timer(timeout));
+            if (offsets == null) {
+                throw new TimeoutException("Timeout of " + timeout.toMillis() + "ms expired before the last " +
+                        "committed offset for partitions " + partitions + " could be determined. Try tuning default.api.timeout.ms " +
+                        "larger to relax the threshold.");
+            } else {
+                offsets.forEach(this::updateLastSeenEpochIfNewer);
+                return offsets;
+            }
+        } finally {
+            kafkaConsumerMetrics.recordCommitted(time.nanoseconds() - start);
         }
-
-        return eventHandler.addAndGet(new OffsetFetchApplicationEvent(partitions), timeout);
     }
 
     private void maybeThrowInvalidGroupIdException() {
@@ -430,42 +551,58 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
 
     @Override
     public Map<MetricName, ? extends Metric> metrics() {
-        throw new KafkaException("method not implemented");
+        return Collections.unmodifiableMap(this.metrics.metrics());
     }
 
     @Override
     public List<PartitionInfo> partitionsFor(String topic) {
-        throw new KafkaException("method not implemented");
+        return partitionsFor(topic, Duration.ofMillis(defaultApiTimeoutMs));
     }
 
     @Override
     public List<PartitionInfo> partitionsFor(String topic, Duration timeout) {
-        throw new KafkaException("method not implemented");
+        Cluster cluster = this.metadata.fetch();
+        List<PartitionInfo> parts = cluster.partitionsForTopic(topic);
+        if (!parts.isEmpty())
+            return parts;
+
+        TopicMetadataApplicationEvent event = new TopicMetadataApplicationEvent(Optional.of(topic));
+        Timer timer = time.timer(timeout);
+        Map<String, List<PartitionInfo>> partitionInfo = eventHandler.addAndGet(event, timer);
+        return partitionInfo.getOrDefault(topic, Collections.emptyList());
     }
 
     @Override
     public Map<String, List<PartitionInfo>> listTopics() {
-        throw new KafkaException("method not implemented");
+        return listTopics(Duration.ofMillis(defaultApiTimeoutMs));
     }
 
     @Override
     public Map<String, List<PartitionInfo>> listTopics(Duration timeout) {
-        throw new KafkaException("method not implemented");
+        TopicMetadataApplicationEvent event = new TopicMetadataApplicationEvent(Optional.empty());
+        Timer timer = time.timer(timeout);
+        return eventHandler.addAndGet(event, timer);
     }
 
     @Override
     public Set<TopicPartition> paused() {
-        throw new KafkaException("method not implemented");
+        return Collections.unmodifiableSet(subscriptions.pausedPartitions());
     }
 
     @Override
     public void pause(Collection<TopicPartition> partitions) {
-        throw new KafkaException("method not implemented");
+        log.debug("Pausing partitions {}", partitions);
+        for (TopicPartition partition: partitions) {
+            subscriptions.pause(partition);
+        }
     }
 
     @Override
     public void resume(Collection<TopicPartition> partitions) {
-        throw new KafkaException("method not implemented");
+        log.debug("Resuming partitions {}", partitions);
+        for (TopicPartition partition: partitions) {
+            subscriptions.resume(partition);
+        }
     }
 
     @Override
@@ -491,7 +628,7 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
         if (timeout.toMillis() == 0L)
             return listOffsetsEvent.emptyResult();
 
-        return eventHandler.addAndGet(listOffsetsEvent, timeout);
+        return eventHandler.addAndGet(listOffsetsEvent, time.timer(timeout));
     }
 
     @Override
@@ -530,14 +667,32 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
                 timestampToSearch,
                 false);
         Map<TopicPartition, OffsetAndTimestamp> offsetAndTimestampMap =
-                eventHandler.addAndGet(listOffsetsEvent, timeout);
+                eventHandler.addAndGet(listOffsetsEvent, time.timer(timeout));
         return offsetAndTimestampMap.entrySet().stream().collect(Collectors.toMap(e -> e.getKey(),
                 e -> e.getValue().offset()));
     }
 
     @Override
     public OptionalLong currentLag(TopicPartition topicPartition) {
-        throw new KafkaException("method not implemented");
+        final Long lag = subscriptions.partitionLag(topicPartition, isolationLevel);
+
+        // if the log end offset is not known and hence cannot return lag and there is
+        // no in-flight list offset requested yet,
+        // issue a list offset request for that partition so that next time
+        // we may get the answer; we do not need to wait for the return value
+        // since we would not try to poll the network client synchronously
+        if (lag == null) {
+            if (subscriptions.partitionEndOffset(topicPartition, isolationLevel) == null &&
+                    !subscriptions.partitionEndOffsetRequested(topicPartition)) {
+                log.info("Requesting the log end offset for {} in order to compute lag", topicPartition);
+                subscriptions.requestPartitionEndOffset(topicPartition);
+                endOffsets(Collections.singleton(topicPartition), Duration.ofMillis(0));
+            }
+
+            return OptionalLong.empty();
+        }
+
+        return OptionalLong.of(lag);
     }
 
     @Override
@@ -560,13 +715,57 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
         close(Duration.ofMillis(DEFAULT_CLOSE_TIMEOUT_MS));
     }
 
+    private Timer createTimerForRequest(final Duration timeout) {
+        // this.time could be null if an exception occurs in constructor prior to setting the this.time field
+        final Time localTime = (time == null) ? Time.SYSTEM : time;
+        return localTime.timer(Math.min(timeout.toMillis(), requestTimeoutMs));
+    }
+
     @Override
     public void close(Duration timeout) {
+        if (timeout.toMillis() < 0)
+            throw new IllegalArgumentException("The timeout cannot be negative.");
+
+        try {
+            if (!closed) {
+                // need to close before setting the flag since the close function
+                // itself may trigger rebalance callback that needs the consumer to be open still
+                close(timeout, false);
+            }
+        } finally {
+            closed = true;
+        }
+    }
+
+    private void close(Duration timeout, boolean swallowException) {
+        log.trace("Closing the Kafka consumer");
         AtomicReference<Throwable> firstException = new AtomicReference<>();
+
+        final Timer closeTimer = createTimerForRequest(timeout);
+        if (fetchBuffer != null) {
+            // the timeout for the session close is at-most the requestTimeoutMs
+            long remainingDurationInTimeout = Math.max(0, timeout.toMillis() - closeTimer.elapsedMs());
+            if (remainingDurationInTimeout > 0) {
+                remainingDurationInTimeout = Math.min(requestTimeoutMs, remainingDurationInTimeout);
+            }
+
+            closeTimer.reset(remainingDurationInTimeout);
+
+            // This is a blocking call bound by the time remaining in closeTimer
+            swallow(log, Level.ERROR, "Failed to close fetcher", fetchBuffer::close, firstException);
+        }
+
+
+        closeQuietly(interceptors, "consumer interceptors", firstException);
+        closeQuietly(kafkaConsumerMetrics, "kafka consumer metrics", firstException);
+        closeQuietly(metrics, "consumer metrics", firstException);
         closeQuietly(this.eventHandler, "event handler", firstException);
+        closeQuietly(deserializers, "consumer deserializers", firstException);
+
+        AppInfoParser.unregisterAppInfo(CONSUMER_JMX_PREFIX, clientId, metrics);
         log.debug("Kafka consumer has been closed");
         Throwable exception = firstException.get();
-        if (exception != null) {
+        if (exception != null && !swallowException) {
             if (exception instanceof InterruptException) {
                 throw (InterruptException) exception;
             }
@@ -596,17 +795,13 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
 
     @Override
     public void commitSync(Map<TopicPartition, OffsetAndMetadata> offsets, Duration timeout) {
-        CompletableFuture<Void> commitFuture = commit(offsets);
+        long commitStart = time.nanoseconds();
         try {
-            commitFuture.get(timeout.toMillis(), TimeUnit.MILLISECONDS);
-        } catch (final TimeoutException e) {
-            throw new org.apache.kafka.common.errors.TimeoutException(e);
-        } catch (final InterruptedException e) {
-            throw new InterruptException(e);
-        } catch (final ExecutionException e) {
-            throw new KafkaException(e);
-        } catch (final Exception e) {
-            throw e;
+            maybeThrowInvalidGroupIdException();
+            offsets.forEach(this::updateLastSeenEpochIfNewer);
+            eventHandler.addAndGet(new CommitApplicationEvent(offsets), time.timer(timeout));
+        } finally {
+            kafkaConsumerMetrics.recordCommitSync(time.nanoseconds() - commitStart);
         }
     }
 
@@ -627,12 +822,38 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
 
     @Override
     public void subscribe(Collection<String> topics) {
-        throw new KafkaException("method not implemented");
+        subscribe(topics, new NoOpConsumerRebalanceListener());
     }
 
     @Override
-    public void subscribe(Collection<String> topics, ConsumerRebalanceListener callback) {
-        throw new KafkaException("method not implemented");
+    public void subscribe(Collection<String> topics, ConsumerRebalanceListener listener) {
+        maybeThrowInvalidGroupIdException();
+        if (topics == null)
+            throw new IllegalArgumentException("Topic collection to subscribe to cannot be null");
+        if (topics.isEmpty()) {
+            // treat subscribing to empty topic list as the same as unsubscribing
+            this.unsubscribe();
+        } else {
+            for (String topic : topics) {
+                if (isBlank(topic))
+                    throw new IllegalArgumentException("Topic collection to subscribe to cannot contain null or empty topic");
+            }
+
+            throwIfNoAssignorsConfigured();
+
+            // Clear the buffered data which are not a part of newly assigned topics
+            final Set<TopicPartition> currentTopicPartitions = new HashSet<>();
+
+            for (TopicPartition tp : subscriptions.assignedPartitions()) {
+                if (topics.contains(tp.topic()))
+                    currentTopicPartitions.add(tp);
+            }
+
+            fetchBuffer.retainAll(currentTopicPartitions);
+            log.info("Subscribed to topic(s): {}", join(topics, ", "));
+            if (this.subscriptions.subscribe(new HashSet<>(topics), listener))
+                metadata.requestUpdateForNewTopics();
+        }
     }
 
     @Override
@@ -677,13 +898,40 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
     }
 
     @Override
-    public void subscribe(Pattern pattern, ConsumerRebalanceListener callback) {
-        throw new KafkaException("method not implemented");
+    public void subscribe(Pattern pattern, ConsumerRebalanceListener listener) {
+        maybeThrowInvalidGroupIdException();
+        if (pattern == null || pattern.toString().equals(""))
+            throw new IllegalArgumentException("Topic pattern to subscribe to cannot be " + (pattern == null ?
+                    "null" : "empty"));
+
+        throwIfNoAssignorsConfigured();
+        log.info("Subscribed to pattern: '{}'", pattern);
+        this.subscriptions.subscribe(pattern, listener);
+        this.updatePatternSubscription(metadata.fetch());
+        this.metadata.requestUpdateForNewTopics();
+    }
+
+    /**
+     * TODO: remove this when we implement the KIP-848 protocol.
+     *
+     * <p>
+     * The contents of this method are shamelessly stolen from
+     * {@link ConsumerCoordinator#updatePatternSubscription(Cluster)} and are used here because we won't have access
+     * to a {@link ConsumerCoordinator} in this code. Perhaps it could be moved to a ConsumerUtils class?
+     *
+     * @param cluster Cluster from which we get the topics
+     */
+    private void updatePatternSubscription(Cluster cluster) {
+        final Set<String> topicsToSubscribe = cluster.topics().stream()
+                .filter(subscriptions::matchesSubscribedPattern)
+                .collect(Collectors.toSet());
+        if (subscriptions.subscribeFromPattern(topicsToSubscribe))
+            metadata.requestUpdateForNewTopics();
     }
 
     @Override
     public void subscribe(Pattern pattern) {
-        throw new KafkaException("method not implemented");
+        subscribe(pattern, new NoOpConsumerRebalanceListener());
     }
 
     @Override
@@ -697,6 +945,95 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
     @Deprecated
     public ConsumerRecords<K, V> poll(final long timeoutMs) {
         return poll(Duration.ofMillis(timeoutMs));
+    }
+
+    private void sendFetches() {
+        if (!eventHandler.isEmpty()) {
+            final Optional<BackgroundEvent> backgroundEvent = eventHandler.poll();
+            // processEvent() may process 3 types of event:
+            // 1. Errors
+            // 2. Callback Invocation
+            // 3. Fetch responses
+            // Errors will be handled or rethrown.
+            // Callback invocation will trigger callback function execution, which is blocking until completion.
+            // Successful fetch responses will be added to the completedFetches in the fetcher, which will then
+            // be processed in the collectFetches().
+            backgroundEvent.ifPresent(event -> log.warn("Do something with this background event: {}", event));
+        }
+
+        FetchEvent<K, V> event = new FetchEvent<>();
+        eventHandler.add(event);
+
+        event.future().whenComplete((completedFetches, error) -> {
+            if (completedFetches != null && !completedFetches.isEmpty()) {
+                fetchBuffer.addAll(completedFetches);
+            }
+        });
+    }
+
+    /**
+     * @throws KafkaException if the rebalance callback throws exception
+     */
+    private Fetch<K, V> pollForFetches(Timer timer) {
+        long pollTimeout = timer.remainingMs();
+
+        // if data is available already, return it immediately
+        final Fetch<K, V> fetch = fetchCollector.collectFetch(fetchBuffer);
+        if (!fetch.isEmpty()) {
+            return fetch;
+        }
+
+        // send any new fetches (won't resend pending fetches)
+        sendFetches();
+
+        // We do not want to be stuck blocking in poll if we are missing some positions
+        // since the offset lookup may be backing off after a failure
+
+        // NOTE: the use of cachedSubscriptionHasAllFetchPositions means we MUST call
+        // updateAssignmentMetadataIfNeeded before this method.
+        if (!cachedSubscriptionHasAllFetchPositions && pollTimeout > retryBackoffMs) {
+            pollTimeout = retryBackoffMs;
+        }
+
+        log.trace("Polling for fetches with timeout {}", pollTimeout);
+
+        Timer pollTimer = time.timer(pollTimeout);
+        Queue<CompletedFetch<K, V>> completedFetches = eventHandler.addAndGet(new FetchEvent<>(), pollTimer);
+        if (completedFetches != null && !completedFetches.isEmpty()) {
+            fetchBuffer.addAll(completedFetches);
+        }
+        timer.update(pollTimer.currentTimeMs());
+
+        return fetchCollector.collectFetch(fetchBuffer);
+    }
+
+    /**
+     * Set the fetch position to the committed position (if there is one)
+     * or reset it using the offset reset policy the user has configured.
+     *
+     * @throws org.apache.kafka.common.errors.AuthenticationException if authentication fails. See the exception for more details
+     * @throws NoOffsetForPartitionException If no offset is stored for a given partition and no offset reset policy is
+     *             defined
+     * @return true iff the operation completed without timing out
+     */
+    private boolean updateFetchPositions(final Timer timer) {
+        // If any partitions have been truncated due to a leader change, we need to validate the offsets
+        ResetPositionsApplicationEvent event = new ResetPositionsApplicationEvent();
+        eventHandler.add(event);
+
+        cachedSubscriptionHasAllFetchPositions = subscriptions.hasAllFetchPositions();
+        if (cachedSubscriptionHasAllFetchPositions) return true;
+
+        // If there are partitions still needing a position and a reset policy is defined,
+        // request reset using the default policy. If no reset strategy is defined and there
+        // are partitions with a missing position, then we will raise an exception.
+        subscriptions.resetInitializingPositions();
+
+        // Finally send an asynchronous request to look up and update the positions of any
+        // partitions which are awaiting reset.
+        eventHandler.add(event);
+
+        return true;
     }
 
     // This is here temporary as we don't have public access to the ConsumerConfig in this module.
@@ -716,11 +1053,31 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
         return newConfigs;
     }
 
+    private void throwIfNoAssignorsConfigured() {
+        if (assignors.isEmpty())
+            throw new IllegalStateException("Must configure at least one partition assigner class name to " +
+                    ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG + " configuration property");
+    }
+
+    private void updateLastSeenEpochIfNewer(TopicPartition topicPartition, OffsetAndMetadata offsetAndMetadata) {
+        if (offsetAndMetadata != null)
+            offsetAndMetadata.leaderEpoch().ifPresent(epoch -> metadata.updateLastSeenEpochIfNewer(topicPartition, epoch));
+    }
+
     private class DefaultOffsetCommitCallback implements OffsetCommitCallback {
         @Override
         public void onComplete(Map<TopicPartition, OffsetAndMetadata> offsets, Exception exception) {
             if (exception != null)
                 log.error("Offset commit with offsets {} failed", offsets, exception);
         }
+    }
+
+    // Functions below are for testing only
+    String getClientId() {
+        return clientId;
+    }
+
+    boolean updateAssignmentMetadataIfNeeded(final Timer timer) {
+        return updateFetchPositions(timer);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumer.java
@@ -955,8 +955,6 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
     }
 
     private void sendFetches() {
-        backgroundEventProcessor.process();
-
         FetchEvent<K, V> event = new FetchEvent<>();
         eventHandler.add(event);
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestManagers.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestManagers.java
@@ -123,7 +123,7 @@ public class RequestManagers<K, V> implements Closeable {
                 final IsolationLevel isolationLevel = getConfiguredIsolationLevel(config);
                 final FetchConfig<K, V> fetchConfig = createFetchConfig(config);
                 final long retryBackoffMs = config.getLong(ConsumerConfig.RETRY_BACKOFF_MS_CONFIG);
-                final long requestTimeoutMs = config.getLong(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG);
+                final int requestTimeoutMs = config.getInt(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG);
                 final OffsetsRequestManager listOffsets = new OffsetsRequestManager(subscriptions,
                         metadata,
                         isolationLevel,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEvent.java
@@ -37,4 +37,26 @@ public abstract class ApplicationEvent {
     public Type type() {
         return type;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        ApplicationEvent that = (ApplicationEvent) o;
+
+        return type == that.type;
+    }
+
+    @Override
+    public int hashCode() {
+        return type.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "ApplicationEvent{" +
+                "type=" + type +
+                '}';
+    }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
@@ -161,8 +161,8 @@ public class ApplicationEventProcessor<K, V> {
 
     private boolean process(final ListOffsetsApplicationEvent event) {
         final CompletableFuture<Map<TopicPartition, OffsetAndTimestamp>> future =
-                requestManagers.offsetsRequestManager.fetchOffsets(event.timestampsToSearch,
-                        event.requireTimestamps);
+                requestManagers.offsetsRequestManager.fetchOffsets(event.timestampsToSearch(),
+                        event.requireTimestamps());
         event.chain(future);
         return true;
     }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
@@ -31,7 +31,6 @@ import org.slf4j.Logger;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Queue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
@@ -199,7 +198,7 @@ public class ApplicationEventProcessor<K, V> {
 
     private boolean process(final TopicMetadataApplicationEvent event) {
         final CompletableFuture<Map<String, List<PartitionInfo>>> future =
-                this.requestManagers.topicMetadataRequestManager.requestTopicMetadata(Optional.of(event.topic()));
+                this.requestManagers.topicMetadataRequestManager.requestTopicMetadata(event.topic());
         event.chain(future);
         return true;
     }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/BackgroundEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/BackgroundEvent.java
@@ -36,4 +36,26 @@ public abstract class BackgroundEvent {
     public Type type() {
         return type;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        BackgroundEvent that = (BackgroundEvent) o;
+
+        return type == that.type;
+    }
+
+    @Override
+    public int hashCode() {
+        return type.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "BackgroundEvent{" +
+                "type=" + type +
+                '}';
+    }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/BackgroundEventProcessor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/BackgroundEventProcessor.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer.internals.events;
+
+import org.apache.kafka.common.utils.LogContext;
+import org.slf4j.Logger;
+
+import java.util.LinkedList;
+import java.util.Objects;
+import java.util.concurrent.BlockingQueue;
+
+public class BackgroundEventProcessor {
+
+    private final Logger log;
+    private final BlockingQueue<BackgroundEvent> backgroundEventQueue;
+
+    public BackgroundEventProcessor(final LogContext logContext,
+                                    final BlockingQueue<BackgroundEvent> backgroundEventQueue) {
+        this.log = logContext.logger(BackgroundEventProcessor.class);
+        this.backgroundEventQueue = backgroundEventQueue;
+    }
+
+    /**
+     * Drains all available {@link BackgroundEvent}s, and then processes them in order. If any
+     * errors are thrown as a result of a {@link ErrorBackgroundEvent} or an error occurs while processing
+     * another type of {@link BackgroundEvent}, only the <em>first</em> exception will be thrown, all
+     * subsequent errors will simply be logged at <code>WARN</code> level.
+     *
+     * @throws RuntimeException or subclass
+     */
+    public void process() {
+        LinkedList<BackgroundEvent> events = new LinkedList<>();
+        backgroundEventQueue.drainTo(events);
+
+        RuntimeException first = null;
+        int errorCount = 0;
+
+        for (BackgroundEvent event : events) {
+            log.debug("Consuming background event: {}", event);
+
+            try {
+                process(event);
+            } catch (RuntimeException e) {
+                errorCount++;
+
+                if (first == null) {
+                    first = e;
+                    log.warn("Error #{} from background thread (will be logged and thrown): {}", errorCount, e.getMessage(), e);
+                } else {
+                    log.warn("Error #{} from background thread (will be logged only): {}", errorCount, e.getMessage(), e);
+                }
+            }
+        }
+
+        if (first != null) {
+            throw first;
+        }
+    }
+
+    private void process(final BackgroundEvent event) {
+        Objects.requireNonNull(event, "Attempt to process null BackgroundEvent");
+        Objects.requireNonNull(event.type(), "Attempt to process BackgroundEvent with null type: " + event);
+
+        log.debug("Processing event {}", event);
+
+        // Make sure to use the event's type() method, not the type variable directly. This causes problems when
+        // unit tests mock the EventType.
+        switch (event.type()) {
+            case NOOP:
+                process((NoopBackgroundEvent) event);
+                return;
+
+            case ERROR:
+                process((ErrorBackgroundEvent) event);
+                return;
+
+            default:
+                throw new IllegalArgumentException("Background event type " + event.type() + " was not expected");
+        }
+    }
+
+    private void process(final NoopBackgroundEvent event) {
+        log.debug("Received no-op background event with message: {}", event.message());
+    }
+
+    private void process(final ErrorBackgroundEvent event) {
+        throw event.error();
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/CommitApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/CommitApplicationEvent.java
@@ -21,8 +21,10 @@ import org.apache.kafka.common.TopicPartition;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.Objects;
 
 public class CommitApplicationEvent extends CompletableApplicationEvent<Void> {
+
     private final Map<TopicPartition, OffsetAndMetadata> offsets;
 
     public CommitApplicationEvent(final Map<TopicPartition, OffsetAndMetadata> offsets) {
@@ -38,6 +40,24 @@ public class CommitApplicationEvent extends CompletableApplicationEvent<Void> {
 
     public Map<TopicPartition, OffsetAndMetadata> offsets() {
         return offsets;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+
+        CommitApplicationEvent that = (CommitApplicationEvent) o;
+
+        return offsets.equals(that.offsets);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + offsets.hashCode();
+        return result;
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/CompletableApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/CompletableApplicationEvent.java
@@ -64,4 +64,30 @@ public abstract class CompletableApplicationEvent<T> extends ApplicationEvent {
             }
         });
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+
+        CompletableApplicationEvent<?> that = (CompletableApplicationEvent<?>) o;
+
+        return future.equals(that.future);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + future.hashCode();
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "CompletableApplicationEvent{" +
+                "future=" + future +
+                ", type=" + type +
+                '}';
+    }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ErrorBackgroundEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ErrorBackgroundEvent.java
@@ -16,16 +16,37 @@
  */
 package org.apache.kafka.clients.consumer.internals.events;
 
-public class ErrorBackgroundEvent extends BackgroundEvent {
-    private final Throwable error;
+import java.util.Objects;
 
-    public ErrorBackgroundEvent(Throwable error) {
+public class ErrorBackgroundEvent extends BackgroundEvent {
+
+    private final RuntimeException error;
+
+    public ErrorBackgroundEvent(RuntimeException error) {
         super(Type.ERROR);
-        this.error = error;
+        this.error = Objects.requireNonNull(error);
     }
 
-    public Throwable error() {
+    public RuntimeException error() {
         return error;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+
+        ErrorBackgroundEvent that = (ErrorBackgroundEvent) o;
+
+        return error.equals(that.error);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + error.hashCode();
+        return result;
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/EventHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/EventHandler.java
@@ -50,36 +50,19 @@ public interface EventHandler extends Closeable {
     boolean add(ApplicationEvent event);
 
     /**
-     * Add an {@link CompletableApplicationEvent} to the handler. The method blocks, waiting for the result, and will
+     * Add a {@link CompletableApplicationEvent} to the handler. The method blocks, waiting for the result, and will
      * return the result value upon successful completion; otherwise throws an error.
      *
      * <p/>
      *
      * See {@link CompletableApplicationEvent#get(Timer)} and {@link Future#get(long, TimeUnit)} for more details.
      *
-     * @param event     An {@link CompletableApplicationEvent} created by the polling thread.
-     * @param timeoutMs Value in milliseconds for which to wait for the event to complete
-     * @return          Value that is the result of the event
-     * @param <T>       Type of return value of the event
+     * @param event An {@link CompletableApplicationEvent} created by the polling thread.
+     * @param timer Timer for which to wait for the event to complete
+     * @return      Value that is the result of the event
+     * @param <T>   Type of return value of the event
      */
-    default <T> T addAndGet(CompletableApplicationEvent<T> event, long timeoutMs) {
-        return addAndGet(event, Duration.ofMillis(timeoutMs));
-    }
-
-    /**
-     * Add an {@link CompletableApplicationEvent} to the handler. The method blocks, waiting for the result, and will
-     * return the result value upon successful completion; otherwise throws an error.
-     *
-     * <p/>
-     *
-     * See {@link CompletableApplicationEvent#get(Timer)} and {@link Future#get(long, TimeUnit)} for more details.
-     *
-     * @param event   An {@link CompletableApplicationEvent} created by the polling thread.
-     * @param timeout Duration in milliseconds for which to wait for the event to complete
-     * @return        Value that is the result of the event
-     * @param <T>     Type of return value of the event
-     */
-    <T> T addAndGet(CompletableApplicationEvent<T> event, Duration timeout);
+    <T> T addAndGet(final CompletableApplicationEvent<T> event, final Timer timer);
 
     default void close() {
         close(Duration.ofMillis(Long.MAX_VALUE));

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/EventHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/EventHandler.java
@@ -20,7 +20,6 @@ import org.apache.kafka.common.utils.Timer;
 
 import java.io.Closeable;
 import java.time.Duration;
-import java.util.Optional;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
@@ -29,17 +28,6 @@ import java.util.concurrent.TimeUnit;
  * the {@code add()} method and to retrieve events via the {@code poll()} method.
  */
 public interface EventHandler extends Closeable {
-    /**
-     * Retrieves and removes a {@link BackgroundEvent}. Returns an empty Optional instance if there is nothing.
-     * @return an Optional of {@link BackgroundEvent} if the value is present. Otherwise, an empty Optional.
-     */
-    Optional<BackgroundEvent> poll();
-
-    /**
-     * Check whether there are pending {@code BackgroundEvent} await to be consumed.
-     * @return true if there are no pending event
-     */
-    boolean isEmpty();
 
     /**
      * Add an {@link ApplicationEvent} to the handler. The method returns true upon successful add; otherwise returns

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ListOffsetsApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ListOffsetsApplicationEvent.java
@@ -19,6 +19,7 @@ package org.apache.kafka.clients.consumer.internals.events;
 import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
 import org.apache.kafka.common.TopicPartition;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -31,20 +32,14 @@ import java.util.Map;
  * or equals to the target timestamp)
  */
 public class ListOffsetsApplicationEvent extends CompletableApplicationEvent<Map<TopicPartition, OffsetAndTimestamp>> {
-    final Map<TopicPartition, Long> timestampsToSearch;
-    final boolean requireTimestamps;
+
+    private final Map<TopicPartition, Long> timestampsToSearch;
+    private final boolean requireTimestamps;
 
     public ListOffsetsApplicationEvent(Map<TopicPartition, Long> timestampToSearch, boolean requireTimestamps) {
         super(Type.LIST_OFFSETS);
-        this.timestampsToSearch = timestampToSearch;
+        this.timestampsToSearch = Collections.unmodifiableMap(timestampToSearch);
         this.requireTimestamps = requireTimestamps;
-    }
-
-    @Override
-    public String toString() {
-        return "ListOffsetsApplicationEvent {" +
-                "timestampsToSearch=" + timestampsToSearch + ", " +
-                "requireTimestamps=" + requireTimestamps + '}';
     }
 
     /**
@@ -59,4 +54,40 @@ public class ListOffsetsApplicationEvent extends CompletableApplicationEvent<Map
             offsetsByTimes.put(entry.getKey(), null);
         return offsetsByTimes;
     }
+
+    public Map<TopicPartition, Long> timestampsToSearch() {
+        return timestampsToSearch;
+    }
+
+    public boolean requireTimestamps() {
+        return requireTimestamps;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+
+        ListOffsetsApplicationEvent that = (ListOffsetsApplicationEvent) o;
+
+        if (requireTimestamps != that.requireTimestamps) return false;
+        return timestampsToSearch.equals(that.timestampsToSearch);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + timestampsToSearch.hashCode();
+        result = 31 * result + (requireTimestamps ? 1 : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "ListOffsetsApplicationEvent {" +
+                "timestampsToSearch=" + timestampsToSearch + ", " +
+                "requireTimestamps=" + requireTimestamps + '}';
+    }
+
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/MetadataUpdateApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/MetadataUpdateApplicationEvent.java
@@ -30,6 +30,24 @@ public class MetadataUpdateApplicationEvent extends ApplicationEvent {
     }
 
     @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+
+        MetadataUpdateApplicationEvent that = (MetadataUpdateApplicationEvent) o;
+
+        return timestamp == that.timestamp;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (int) (timestamp ^ (timestamp >>> 32));
+        return result;
+    }
+
+    @Override
     public String toString() {
         return "MetadataUpdateApplicationEvent{" +
                 "timestamp=" + timestamp +

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/NoopApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/NoopApplicationEvent.java
@@ -35,6 +35,24 @@ public class NoopApplicationEvent extends ApplicationEvent {
     }
 
     @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+
+        NoopApplicationEvent that = (NoopApplicationEvent) o;
+
+        return message.equals(that.message);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + message.hashCode();
+        return result;
+    }
+
+    @Override
     public String toString() {
         return "NoopApplicationEvent{" +
                 "message='" + message + '\'' +

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/NoopBackgroundEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/NoopBackgroundEvent.java
@@ -35,6 +35,24 @@ public class NoopBackgroundEvent extends BackgroundEvent {
     }
 
     @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+
+        NoopBackgroundEvent that = (NoopBackgroundEvent) o;
+
+        return message.equals(that.message);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + message.hashCode();
+        return result;
+    }
+
+    @Override
     public String toString() {
         return "NoopBackgroundEvent{" +
                 "message='" + message + '\'' +

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/OffsetFetchApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/OffsetFetchApplicationEvent.java
@@ -37,6 +37,24 @@ public class OffsetFetchApplicationEvent extends CompletableApplicationEvent<Map
     }
 
     @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+
+        OffsetFetchApplicationEvent that = (OffsetFetchApplicationEvent) o;
+
+        return partitions.equals(that.partitions);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + partitions.hashCode();
+        return result;
+    }
+
+    @Override
     public String toString() {
         return "OffsetFetchApplicationEvent{" +
                 "partitions=" + partitions +

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/PollApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/PollApplicationEvent.java
@@ -30,6 +30,24 @@ public class PollApplicationEvent extends ApplicationEvent {
     }
 
     @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+
+        PollApplicationEvent that = (PollApplicationEvent) o;
+
+        return pollTimeMs == that.pollTimeMs;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (int) (pollTimeMs ^ (pollTimeMs >>> 32));
+        return result;
+    }
+
+    @Override
     public String toString() {
         return "PollApplicationEvent{" +
                 "pollTimeMs=" + pollTimeMs +

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/TopicMetadataApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/TopicMetadataApplicationEvent.java
@@ -45,6 +45,24 @@ public class TopicMetadataApplicationEvent extends CompletableApplicationEvent<M
     }
 
     @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+
+        TopicMetadataApplicationEvent that = (TopicMetadataApplicationEvent) o;
+
+        return topic.equals(that.topic);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + topic.hashCode();
+        return result;
+    }
+
+    @Override
     public String toString() {
         return "TopicMetadataApplicationEvent{" +
                 "topic=" + topic +

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/TopicMetadataApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/TopicMetadataApplicationEvent.java
@@ -20,15 +20,36 @@ import org.apache.kafka.common.PartitionInfo;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 
 public class TopicMetadataApplicationEvent extends CompletableApplicationEvent<Map<String, List<PartitionInfo>>> {
-    private final String topic;
-    public TopicMetadataApplicationEvent(final String topic) {
+
+    private final Optional<String> topic;
+
+    /**
+     * Topic metadata can be retrieved for either a single topic or all topics. For the single-topic case, the
+     * value of the topic name is passed into the {@link Optional#of(Object)} and only its metadata will be
+     * retrieved. To look up the metadata of all topics, pass in {@link Optional#empty()}.
+     *
+     * @param topic Use {@link Optional#of(Object)} to retrieve a single topic's metadata, or {@link Optional#empty()}
+     *              to find the metadata of all the topics
+     */
+    public TopicMetadataApplicationEvent(final Optional<String> topic) {
         super(Type.TOPIC_METADATA);
-        this.topic = topic;
+        this.topic = Objects.requireNonNull(topic);
     }
 
-    public String topic() {
+    public Optional<String> topic() {
         return topic;
+    }
+
+    @Override
+    public String toString() {
+        return "TopicMetadataApplicationEvent{" +
+                "topic=" + topic +
+                ", future=" + future +
+                ", type=" + type +
+                '}';
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerTestBuilder.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerTestBuilder.java
@@ -21,6 +21,7 @@ import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.GroupRebalanceConfig;
 import org.apache.kafka.clients.MockClient;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor;
 import org.apache.kafka.clients.consumer.internals.events.ApplicationEvent;
 import org.apache.kafka.clients.consumer.internals.events.ApplicationEventProcessor;
 import org.apache.kafka.clients.consumer.internals.events.BackgroundEvent;
@@ -38,6 +39,7 @@ import org.apache.kafka.common.utils.Time;
 import java.io.Closeable;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.BlockingQueue;
@@ -62,9 +64,11 @@ public class ConsumerTestBuilder implements Closeable {
     final BlockingQueue<ApplicationEvent> applicationEventQueue;
     final LinkedBlockingQueue<BackgroundEvent> backgroundEventQueue;
     final ConsumerConfig config;
+    final long retryBackoffMs;
     final SubscriptionState subscriptions;
     final ConsumerMetadata metadata;
     final FetchConfig<String, String> fetchConfig;
+    final Metrics metrics;
     final FetchMetricsManager metricsManager;
     final NetworkClientDelegate networkClientDelegate;
     final OffsetsRequestManager offsetsRequestManager;
@@ -109,9 +113,9 @@ public class ConsumerTestBuilder implements Closeable {
 
         this.config = new ConsumerConfig(properties);
         IsolationLevel isolationLevel = getConfiguredIsolationLevel(config);
-        final long retryBackoffMs = config.getLong(ConsumerConfig.RETRY_BACKOFF_MS_CONFIG);
+        this.retryBackoffMs = config.getLong(ConsumerConfig.RETRY_BACKOFF_MS_CONFIG);
         final long requestTimeoutMs = config.getInt(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG);
-        Metrics metrics = createMetrics(config, time);
+        this.metrics = createMetrics(config, time);
 
         this.subscriptions = createSubscriptionState(config, logContext);
         this.metadata = spy(new ConsumerMetadata(config, subscriptions, logContext, new ClusterResourceListeners()));
@@ -217,22 +221,34 @@ public class ConsumerTestBuilder implements Closeable {
         final PrototypeAsyncConsumer<String, String> consumer;
 
         public PrototypeAsyncConsumerTestBuilder(Optional<String> groupIdOpt) {
+            String clientId = config.getString(CommonClientConfigs.CLIENT_ID_CONFIG);
+            List<ConsumerPartitionAssignor> assignors = ConsumerPartitionAssignor.getAssignorInstances(
+                    config.getList(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG),
+                    config.originals(Collections.singletonMap(ConsumerConfig.CLIENT_ID_CONFIG, clientId))
+            );
             FetchCollector<String, String> fetchCollector = new FetchCollector<>(logContext,
                     metadata,
                     subscriptions,
                     fetchConfig,
                     metricsManager,
                     time);
-            this.consumer = spy(new PrototypeAsyncConsumer<>(logContext,
+            this.consumer = spy(new PrototypeAsyncConsumer<>(
+                    logContext,
+                    clientId,
+                    new Deserializers<>(new StringDeserializer(), new StringDeserializer()),
+                    new FetchBuffer<>(logContext),
+                    fetchCollector,
+                    new ConsumerInterceptors<>(Collections.emptyList()),
                     time,
                     eventHandler,
-                    groupIdOpt,
+                    metrics,
                     subscriptions,
-                    3000,
                     metadata,
-                    new ConsumerInterceptors<>(Collections.emptyList()),
-                    new FetchBuffer<>(logContext),
-                    fetchCollector));
+                    retryBackoffMs,
+                    REQUEST_TIMEOUT_MS,
+                    60000,
+                    assignors,
+                    groupIdOpt.orElse(null)));
         }
 
         @Override

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerTestBuilder.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerTestBuilder.java
@@ -25,6 +25,7 @@ import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor;
 import org.apache.kafka.clients.consumer.internals.events.ApplicationEvent;
 import org.apache.kafka.clients.consumer.internals.events.ApplicationEventProcessor;
 import org.apache.kafka.clients.consumer.internals.events.BackgroundEvent;
+import org.apache.kafka.clients.consumer.internals.events.BackgroundEventProcessor;
 import org.apache.kafka.clients.consumer.internals.events.EventHandler;
 import org.apache.kafka.common.IsolationLevel;
 import org.apache.kafka.common.internals.ClusterResourceListeners;
@@ -78,6 +79,7 @@ public class ConsumerTestBuilder implements Closeable {
     final FetchRequestManager<String, String> fetchRequestManager;
     final RequestManagers<String, String> requestManagers;
     final ApplicationEventProcessor<String, String> applicationEventProcessor;
+    final BackgroundEventProcessor backgroundEventProcessor;
     final MockClient client;
 
     private final String topic1 = "test1";
@@ -168,6 +170,7 @@ public class ConsumerTestBuilder implements Closeable {
                 requestManagers,
                 metadata,
                 logContext));
+        this.backgroundEventProcessor = spy(new BackgroundEventProcessor(logContext, backgroundEventQueue));
     }
 
     @Override
@@ -241,6 +244,7 @@ public class ConsumerTestBuilder implements Closeable {
                     new ConsumerInterceptors<>(Collections.emptyList()),
                     time,
                     eventHandler,
+                    backgroundEventQueue,
                     metrics,
                     subscriptions,
                     metadata,

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThreadTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThreadTest.java
@@ -101,8 +101,8 @@ public class DefaultBackgroundThreadTest {
 
     @Test
     public void testStartupAndTearDown() throws InterruptedException {
-        backgroundThread.start();
         assertFalse(backgroundThread.isRunning());
+        backgroundThread.start();
 
         // There's a nonzero amount of time between starting the thread and having it
         // begin to execute our code. Wait for a bit before checking...
@@ -110,10 +110,10 @@ public class DefaultBackgroundThreadTest {
         TestUtils.waitForCondition(backgroundThread::isRunning,
                 maxWaitMs,
                 "Thread did not start within " + maxWaitMs + " ms");
-
-        assertTrue(backgroundThread.isRunning());
         backgroundThread.close();
-        assertFalse(backgroundThread.isRunning());
+        TestUtils.waitForCondition(() -> !backgroundThread.isRunning(),
+                maxWaitMs,
+                "Thread did not stop within " + maxWaitMs + " ms");
     }
 
     @Test
@@ -196,7 +196,7 @@ public class DefaultBackgroundThreadTest {
     @Test
     void testFetchTopicMetadata() {
         when(this.topicMetadataRequestManager.requestTopicMetadata(Optional.of(anyString()))).thenReturn(new CompletableFuture<>());
-        this.applicationEventsQueue.add(new TopicMetadataApplicationEvent("topic"));
+        this.applicationEventsQueue.add(new TopicMetadataApplicationEvent(Optional.of("topic")));
         backgroundThread.runOnce();
         verify(applicationEventProcessor).process(any(TopicMetadataApplicationEvent.class));
         backgroundThread.close();

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/DefaultEventHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/DefaultEventHandlerTest.java
@@ -26,8 +26,6 @@ import org.junit.jupiter.api.Test;
 import java.util.concurrent.BlockingQueue;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DefaultEventHandlerTest {
 
@@ -50,8 +48,6 @@ public class DefaultEventHandlerTest {
 
     @Test
     public void testBasicHandlerOps() {
-        assertTrue(handler.isEmpty());
-        assertFalse(handler.poll().isPresent());
         handler.add(new NoopApplicationEvent("test"));
         assertEquals(1, aq.size());
     }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ErrorEventHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ErrorEventHandlerTest.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer.internals;
+
+import org.apache.kafka.clients.consumer.internals.events.BackgroundEvent;
+import org.apache.kafka.clients.consumer.internals.events.BackgroundEventProcessor;
+import org.apache.kafka.clients.consumer.internals.events.ErrorBackgroundEvent;
+import org.apache.kafka.clients.consumer.internals.events.NoopBackgroundEvent;
+import org.apache.kafka.common.KafkaException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.BlockingQueue;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class ErrorEventHandlerTest {
+
+    private ConsumerTestBuilder.DefaultEventHandlerTestBuilder testBuilder;
+    private BlockingQueue<BackgroundEvent> backgroundEventQueue;
+    private ErrorEventHandler errorEventHandler;
+    private BackgroundEventProcessor backgroundEventProcessor;
+
+    @BeforeEach
+    public void setup() {
+        testBuilder = new ConsumerTestBuilder.DefaultEventHandlerTestBuilder();
+        backgroundEventQueue = testBuilder.backgroundEventQueue;
+        errorEventHandler = new ErrorEventHandler(backgroundEventQueue);
+        backgroundEventProcessor = new BackgroundEventProcessor(testBuilder.logContext, backgroundEventQueue);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (testBuilder != null)
+            testBuilder.close();
+    }
+
+    @Test
+    public void testNoEvents() {
+        assertTrue(backgroundEventQueue.isEmpty());
+        backgroundEventProcessor.process();
+        assertTrue(backgroundEventQueue.isEmpty());
+    }
+
+    @Test
+    public void testSingleEvent() {
+        BackgroundEvent event = new NoopBackgroundEvent("A");
+        backgroundEventQueue.add(event);
+        assertPeeked(event);
+        backgroundEventProcessor.process();
+        assertTrue(backgroundEventQueue.isEmpty());
+    }
+
+    @Test
+    public void testSingleErrorEvent() {
+        KafkaException error = new KafkaException("error");
+        BackgroundEvent event = new ErrorBackgroundEvent(error);
+        errorEventHandler.handle(error);
+        assertPeeked(event);
+        assertThrows(error);
+    }
+
+    @Test
+    public void testInvalidEvent() {
+        String message = "I'm a naughty error!";
+        BackgroundEvent event = new BackgroundEvent(BackgroundEvent.Type.NOOP) {
+            @Override
+            public Type type() {
+                return null;
+            }
+
+            @Override
+            public String toString() {
+                return message;
+            }
+        };
+
+        backgroundEventQueue.add(event);
+        assertPeeked(event);
+
+        Exception error = new NullPointerException(String.format("Attempt to process BackgroundEvent with null type: %s", message));
+        assertThrows(error);
+    }
+
+    @Test
+    public void testMultipleEvents() {
+        BackgroundEvent event1 = new NoopBackgroundEvent("A");
+        backgroundEventQueue.add(event1);
+        backgroundEventQueue.add(new NoopBackgroundEvent("B"));
+        backgroundEventQueue.add(new NoopBackgroundEvent("C"));
+
+        assertPeeked(event1);
+        backgroundEventProcessor.process();
+        assertTrue(backgroundEventQueue.isEmpty());
+    }
+
+    @Test
+    public void testMultipleErrorEvents() {
+        Throwable error1 = new Throwable("error1");
+        KafkaException error2 = new KafkaException("error2");
+        KafkaException error3 = new KafkaException("error3");
+
+        errorEventHandler.handle(error1);
+        errorEventHandler.handle(error2);
+        errorEventHandler.handle(error3);
+
+        assertThrows(new RuntimeException(error1));
+    }
+
+    @Test
+    public void testMixedEventsWithErrorEvents() {
+        Throwable error1 = new Throwable("error1");
+        KafkaException error2 = new KafkaException("error2");
+        KafkaException error3 = new KafkaException("error3");
+
+        backgroundEventQueue.add(new NoopBackgroundEvent("A"));
+        errorEventHandler.handle(error1);
+        backgroundEventQueue.add(new NoopBackgroundEvent("B"));
+        errorEventHandler.handle(error2);
+        backgroundEventQueue.add(new NoopBackgroundEvent("C"));
+        errorEventHandler.handle(error3);
+        backgroundEventQueue.add(new NoopBackgroundEvent("D"));
+
+        assertThrows(new RuntimeException(error1));
+    }
+
+    private void assertPeeked(BackgroundEvent event) {
+        BackgroundEvent peekEvent = backgroundEventQueue.peek();
+        assertNotNull(peekEvent);
+        assertEquals(event, peekEvent);
+    }
+
+    private void assertThrows(Throwable error) {
+        assertFalse(backgroundEventQueue.isEmpty());
+
+        try {
+            backgroundEventProcessor.process();
+            fail("Should have thrown error: " + error);
+        } catch (Throwable t) {
+            assertEquals(error.getClass(), t.getClass());
+            assertEquals(error.getMessage(), t.getMessage());
+        }
+
+        assertTrue(backgroundEventQueue.isEmpty());
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumerTest.java
@@ -29,6 +29,7 @@ import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.InvalidGroupIdException;
 import org.apache.kafka.common.errors.TimeoutException;
+import org.apache.kafka.common.utils.Timer;
 import org.apache.kafka.test.TestUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -149,7 +150,7 @@ public class PrototypeAsyncConsumerTest {
             assertNotNull(constructedEvents);
             assertEquals(1, constructedEvents.size());
             OffsetFetchApplicationEvent event = constructedEvents.get(0);
-            verify(eventHandler).addAndGet(eq(event), any(Duration.class));
+            verify(eventHandler).addAndGet(eq(event), any(Timer.class));
         }
     }
 
@@ -204,7 +205,7 @@ public class PrototypeAsyncConsumerTest {
                 .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue().offset()));
         assertEquals(expectedOffsets, result);
         verify(eventHandler).addAndGet(ArgumentMatchers.isA(ListOffsetsApplicationEvent.class),
-                ArgumentMatchers.isA(Duration.class));
+                ArgumentMatchers.isA(Timer.class));
     }
 
     @Test
@@ -217,7 +218,7 @@ public class PrototypeAsyncConsumerTest {
                 () -> consumer.beginningOffsets(partitions,
                         Duration.ofMillis(1)));
         assertEquals(eventProcessingFailure, consumerError);
-        verify(eventHandler).addAndGet(ArgumentMatchers.isA(ListOffsetsApplicationEvent.class), ArgumentMatchers.isA(Duration.class));
+        verify(eventHandler).addAndGet(ArgumentMatchers.isA(ListOffsetsApplicationEvent.class), ArgumentMatchers.isA(Timer.class));
     }
 
     @Test
@@ -228,7 +229,7 @@ public class PrototypeAsyncConsumerTest {
                         Collections.singletonList(new TopicPartition("t1", 0)),
                         Duration.ofMillis(1)));
         verify(eventHandler).addAndGet(ArgumentMatchers.isA(ListOffsetsApplicationEvent.class),
-                ArgumentMatchers.isA(Duration.class));
+                ArgumentMatchers.isA(Timer.class));
     }
 
     @Test
@@ -247,7 +248,7 @@ public class PrototypeAsyncConsumerTest {
                 assertDoesNotThrow(() -> consumer.offsetsForTimes(timestampToSearch, Duration.ofMillis(1)));
         assertEquals(expectedResult, result);
         verify(eventHandler).addAndGet(ArgumentMatchers.isA(ListOffsetsApplicationEvent.class),
-                ArgumentMatchers.isA(Duration.class));
+                ArgumentMatchers.isA(Timer.class));
     }
 
     // This test ensures same behaviour as the current consumer when offsetsForTimes is called
@@ -265,7 +266,7 @@ public class PrototypeAsyncConsumerTest {
                         Duration.ofMillis(0)));
         assertEquals(expectedResult, result);
         verify(eventHandler, never()).addAndGet(ArgumentMatchers.isA(ListOffsetsApplicationEvent.class),
-                ArgumentMatchers.isA(Duration.class));
+                ArgumentMatchers.isA(Timer.class));
     }
 
     private HashMap<TopicPartition, OffsetAndMetadata> mockTopicPartitionOffset() {


### PR DESCRIPTION
There are several `Consumer` APIs that only touch the `ConsumerMetadata` and/or `SubscriptionState` classes; they do not perform network I/O or otherwise block. These can be implemented without needing `RequestManager` updates and include the following APIs:

- `committed`
- `currentLag`
- `listTopics`
- `metrics`
- `partitionsFor`
- `pause`
- `paused`
- `position`
- `resume`
- `seek`
- `seekToBeginning`
- `seekToEnd`
- `subscribe`