### PR TITLE
Reset positions misc fixes & tests

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ListOffsetsRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ListOffsetsRequestManager.java
@@ -158,13 +158,21 @@ public class ListOffsetsRequestManager implements RequestManager, ClusterResourc
                 offsetFetcherUtils.buildOffsetsForTimesResult(timestampsToSearch, result.fetchedOffsets));
     }
 
+    /**
+     * Reset offsets for all assigned partitions that require it. Offsets will be reset
+     * with timestamps according to the reset strategy defined for each partition.
+     * <p>
+     * This may throw exception from previous offset fetch if there is one, ex.
+     * TopicAuthorizationException
+     */
     public void resetPositionsIfNeeded() {
         Map<TopicPartition, Long> offsetResetTimestamps = offsetFetcherUtils.getOffsetResetTimestamp();
 
         if (offsetResetTimestamps.isEmpty())
             return;
 
-        sendListOffsetsRequestsAndResetPositions(offsetResetTimestamps);
+        List<NetworkClientDelegate.UnsentRequest> unsentRequests = sendListOffsetsRequestsAndResetPositions(offsetResetTimestamps);
+        requestsToSend.addAll(unsentRequests);
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
@@ -172,21 +172,12 @@ public class ApplicationEventProcessor<K, V> {
      * the reset strategy defined. It will also update in-memory positions based on the retrieved
      * offsets.
      * <p>
-     * In the case a request is performed and the response contains some error, the exception
-     * will be cached, to be thrown the next time a reset event is processed.
-     * <p>
-     * The ResetPositionsApplicationEvent event future completes when the resetPositions has been
-     * successfully processed. It fails if an error occur while processing the event, or if there
-     * is a cached exception from a previous ListOffsetRequest request.
+     * This may throw an exception cached in memory from the previous request if it failed.
      */
     private boolean process(final ResetPositionsApplicationEvent event) {
-        try {
-            requestManagers.listOffsetsRequestManager.resetPositionsIfNeeded();
-            event.future().complete(null);
-        } catch (Exception e) {
-            log.error("Reset positions event failed", e);
-            event.future().completeExceptionally(e);
-        }
+        requestManagers.listOffsetsRequestManager.resetPositionsIfNeeded();
+        // TODO: chain future to process failures at a higher level once the caching logic for
+        //  exceptions is reviewed/removed
         return true;
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ResetPositionsApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ResetPositionsApplicationEvent.java
@@ -17,16 +17,20 @@
 
 package org.apache.kafka.clients.consumer.internals.events;
 
-import org.apache.kafka.common.TopicPartition;
-
-import java.util.Map;
-
 /**
  * Event for resetting offsets for all assigned partitions that require it.
  */
-public class ResetPositionsApplicationEvent extends CompletableApplicationEvent<Map<TopicPartition, Long>> {
+public class ResetPositionsApplicationEvent extends CompletableApplicationEvent<Void> {
 
     public ResetPositionsApplicationEvent() {
         super(Type.RESET_POSITIONS);
+    }
+
+    @Override
+    public String toString() {
+        return "ResetPositions{" +
+                "future=" + future +
+                ", type=" + type +
+                '}';
     }
 }


### PR DESCRIPTION
Misc changes for error handling and fix for registering requests. 

Regarding the error handling, this PR includes an initial implementation that maintains the current logic for caching exceptions when the reset positions request response contains an error. Cached exceptions are thrown in the next call to the reset positions, so it does not need to wait for the response to fail. Based on this, this initial approach requires no future result for the reset event processing.

This approach will be reviewed in a follow-up task, to potentially remove the caching logic and use a completableFuture as the means to propagate the errors received in the response asynchronously.
