### PR TITLE
KAFKA-15163; [1/N] Validate positions & updateFetchPositions in consumer poll

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -80,7 +80,7 @@
               files="MemoryRecordsBuilder.java"/>
 
     <suppress checks="ClassDataAbstractionCoupling"
-              files="(KafkaConsumer|ConsumerCoordinator|AbstractFetch|KafkaProducer|AbstractRequest|AbstractResponse|TransactionManager|Admin|KafkaAdminClient|MockAdminClient|KafkaRaftClient|KafkaRaftClientTest).java"/>
+              files="(KafkaConsumer|PrototypeAsyncConsumer|ConsumerCoordinator|AbstractFetch|KafkaProducer|AbstractRequest|AbstractResponse|TransactionManager|Admin|KafkaAdminClient|MockAdminClient|KafkaRaftClient|KafkaRaftClientTest).java"/>
     <suppress checks="ClassDataAbstractionCoupling"
               files="(Errors|SaslAuthenticatorTest|AgentTest|CoordinatorTest).java"/>
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetFetcherUtils.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetFetcherUtils.java
@@ -18,6 +18,8 @@ package org.apache.kafka.clients.consumer.internals;
 
 import org.apache.kafka.clients.ApiVersions;
 import org.apache.kafka.clients.NodeApiVersions;
+import org.apache.kafka.clients.consumer.LogTruncationException;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
 import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.common.IsolationLevel;
@@ -37,9 +39,11 @@ import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 import org.slf4j.Logger;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -313,6 +317,58 @@ class OffsetFetcherUtils {
         if (!(error instanceof RetriableException) && !cachedListOffsetsException.compareAndSet(null,
                 error))
             log.error("Discarding error in ListOffsetResponse because another error is pending", error);
+    }
+
+
+    void onSuccessfulRequestForValidatingPositions(
+            final Map<TopicPartition, SubscriptionState.FetchPosition> fetchPositions,
+            final OffsetsForLeaderEpochUtils.OffsetForEpochResult offsetsResult) {
+        List<SubscriptionState.LogTruncation> truncations = new ArrayList<>();
+        if (!offsetsResult.partitionsToRetry().isEmpty()) {
+            subscriptionState.setNextAllowedRetry(offsetsResult.partitionsToRetry(),
+                    time.milliseconds() + retryBackoffMs);
+            metadata.requestUpdate();
+        }
+
+        // For each OffsetsForLeader response, check if the end-offset is lower than our current offset
+        // for the partition. If so, it means we have experienced log truncation and need to reposition
+        // that partition's offset.
+        // In addition, check whether the returned offset and epoch are valid. If not, then we should reset
+        // its offset if reset policy is configured, or throw out of range exception.
+        offsetsResult.endOffsets().forEach((topicPartition, respEndOffset) -> {
+            SubscriptionState.FetchPosition requestPosition = fetchPositions.get(topicPartition);
+            Optional<SubscriptionState.LogTruncation> truncationOpt =
+                    subscriptionState.maybeCompleteValidation(topicPartition, requestPosition,
+                            respEndOffset);
+            truncationOpt.ifPresent(truncations::add);
+        });
+
+        if (!truncations.isEmpty()) {
+            maybeSetOffsetForLeaderException(buildLogTruncationException(truncations));
+        }
+    }
+
+    void onFailedRequestForValidatingPositions(final Map<TopicPartition,
+            SubscriptionState.FetchPosition> fetchPositions,
+                                               final RuntimeException error) {
+        subscriptionState.requestFailed(fetchPositions.keySet(), time.milliseconds() + retryBackoffMs);
+        metadata.requestUpdate();
+
+        if (!(error instanceof RetriableException)) {
+            maybeSetOffsetForLeaderException(error);
+        }
+    }
+
+    private LogTruncationException buildLogTruncationException(List<SubscriptionState.LogTruncation> truncations) {
+        Map<TopicPartition, OffsetAndMetadata> divergentOffsets = new HashMap<>();
+        Map<TopicPartition, Long> truncatedFetchOffsets = new HashMap<>();
+        for (SubscriptionState.LogTruncation truncation : truncations) {
+            truncation.divergentOffsetOpt.ifPresent(divergentOffset ->
+                    divergentOffsets.put(truncation.topicPartition, divergentOffset));
+            truncatedFetchOffsets.put(truncation.topicPartition, truncation.fetchPosition.offset);
+        }
+        return new LogTruncationException("Detected truncated partitions: " + truncations,
+                truncatedFetchOffsets, divergentOffsets);
     }
 
     // Visible for testing

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetsForLeaderEpochClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetsForLeaderEpochClient.java
@@ -18,23 +18,12 @@ package org.apache.kafka.clients.consumer.internals;
 
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.errors.TopicAuthorizationException;
-import org.apache.kafka.common.message.OffsetForLeaderEpochRequestData.OffsetForLeaderPartition;
-import org.apache.kafka.common.message.OffsetForLeaderEpochRequestData.OffsetForLeaderTopic;
-import org.apache.kafka.common.message.OffsetForLeaderEpochRequestData.OffsetForLeaderTopicCollection;
-import org.apache.kafka.common.message.OffsetForLeaderEpochResponseData.EpochEndOffset;
-import org.apache.kafka.common.message.OffsetForLeaderEpochResponseData.OffsetForLeaderTopicResult;
-import org.apache.kafka.common.protocol.Errors;
-import org.apache.kafka.common.record.RecordBatch;
 import org.apache.kafka.common.requests.AbstractRequest;
 import org.apache.kafka.common.requests.OffsetsForLeaderEpochRequest;
 import org.apache.kafka.common.requests.OffsetsForLeaderEpochResponse;
 import org.apache.kafka.common.utils.LogContext;
 
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * Convenience class for making asynchronous requests to the OffsetsForLeaderEpoch API
@@ -43,7 +32,7 @@ public class OffsetsForLeaderEpochClient extends AsyncClient<
         Map<TopicPartition, SubscriptionState.FetchPosition>,
         OffsetsForLeaderEpochRequest,
         OffsetsForLeaderEpochResponse,
-        OffsetsForLeaderEpochClient.OffsetForEpochResult> {
+        OffsetsForLeaderEpochUtils.OffsetForEpochResult> {
 
     OffsetsForLeaderEpochClient(ConsumerNetworkClient client, LogContext logContext) {
         super(client, logContext);
@@ -52,98 +41,15 @@ public class OffsetsForLeaderEpochClient extends AsyncClient<
     @Override
     protected AbstractRequest.Builder<OffsetsForLeaderEpochRequest> prepareRequest(
             Node node, Map<TopicPartition, SubscriptionState.FetchPosition> requestData) {
-        OffsetForLeaderTopicCollection topics = new OffsetForLeaderTopicCollection(requestData.size());
-        requestData.forEach((topicPartition, fetchPosition) ->
-            fetchPosition.offsetEpoch.ifPresent(fetchEpoch -> {
-                OffsetForLeaderTopic topic = topics.find(topicPartition.topic());
-                if (topic == null) {
-                    topic = new OffsetForLeaderTopic().setTopic(topicPartition.topic());
-                    topics.add(topic);
-                }
-                topic.partitions().add(new OffsetForLeaderPartition()
-                    .setPartition(topicPartition.partition())
-                    .setLeaderEpoch(fetchEpoch)
-                    .setCurrentLeaderEpoch(fetchPosition.currentLeader.epoch
-                        .orElse(RecordBatch.NO_PARTITION_LEADER_EPOCH))
-                );
-            })
-        );
-        return OffsetsForLeaderEpochRequest.Builder.forConsumer(topics);
+        return OffsetsForLeaderEpochUtils.prepareRequest(requestData);
     }
 
     @Override
-    protected OffsetForEpochResult handleResponse(
+    protected OffsetsForLeaderEpochUtils.OffsetForEpochResult handleResponse(
             Node node,
             Map<TopicPartition, SubscriptionState.FetchPosition> requestData,
             OffsetsForLeaderEpochResponse response) {
 
-        Set<TopicPartition> partitionsToRetry = new HashSet<>(requestData.keySet());
-        Set<String> unauthorizedTopics = new HashSet<>();
-        Map<TopicPartition, EpochEndOffset> endOffsets = new HashMap<>();
-
-        for (OffsetForLeaderTopicResult topic : response.data().topics()) {
-            for (EpochEndOffset partition : topic.partitions()) {
-                TopicPartition topicPartition = new TopicPartition(topic.topic(), partition.partition());
-
-                if (!requestData.containsKey(topicPartition)) {
-                    logger().warn("Received unrequested topic or partition {} from response, ignoring.", topicPartition);
-                    continue;
-                }
-
-                Errors error = Errors.forCode(partition.errorCode());
-                switch (error) {
-                    case NONE:
-                        logger().debug("Handling OffsetsForLeaderEpoch response for {}. Got offset {} for epoch {}.",
-                            topicPartition, partition.endOffset(), partition.leaderEpoch());
-                        endOffsets.put(topicPartition, partition);
-                        partitionsToRetry.remove(topicPartition);
-                        break;
-                    case NOT_LEADER_OR_FOLLOWER:
-                    case REPLICA_NOT_AVAILABLE:
-                    case KAFKA_STORAGE_ERROR:
-                    case OFFSET_NOT_AVAILABLE:
-                    case LEADER_NOT_AVAILABLE:
-                    case FENCED_LEADER_EPOCH:
-                    case UNKNOWN_LEADER_EPOCH:
-                        logger().debug("Attempt to fetch offsets for partition {} failed due to {}, retrying.",
-                            topicPartition, error);
-                        break;
-                    case UNKNOWN_TOPIC_OR_PARTITION:
-                        logger().warn("Received unknown topic or partition error in OffsetsForLeaderEpoch request for partition {}.",
-                            topicPartition);
-                        break;
-                    case TOPIC_AUTHORIZATION_FAILED:
-                        unauthorizedTopics.add(topicPartition.topic());
-                        partitionsToRetry.remove(topicPartition);
-                        break;
-                    default:
-                        logger().warn("Attempt to fetch offsets for partition {} failed due to: {}, retrying.",
-                            topicPartition, error.message());
-                }
-            }
-        }
-
-        if (!unauthorizedTopics.isEmpty())
-            throw new TopicAuthorizationException(unauthorizedTopics);
-        else
-            return new OffsetForEpochResult(endOffsets, partitionsToRetry);
-    }
-
-    public static class OffsetForEpochResult {
-        private final Map<TopicPartition, EpochEndOffset> endOffsets;
-        private final Set<TopicPartition> partitionsToRetry;
-
-        OffsetForEpochResult(Map<TopicPartition, EpochEndOffset> endOffsets, Set<TopicPartition> partitionsNeedingRetry) {
-            this.endOffsets = endOffsets;
-            this.partitionsToRetry = partitionsNeedingRetry;
-        }
-
-        public Map<TopicPartition, EpochEndOffset> endOffsets() {
-            return endOffsets;
-        }
-
-        public Set<TopicPartition> partitionsToRetry() {
-            return partitionsToRetry;
-        }
+        return OffsetsForLeaderEpochUtils.handleResponse(requestData, response);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetsForLeaderEpochUtils.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetsForLeaderEpochUtils.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer.internals;
+
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.TopicAuthorizationException;
+import org.apache.kafka.common.message.OffsetForLeaderEpochRequestData.OffsetForLeaderPartition;
+import org.apache.kafka.common.message.OffsetForLeaderEpochRequestData.OffsetForLeaderTopic;
+import org.apache.kafka.common.message.OffsetForLeaderEpochRequestData.OffsetForLeaderTopicCollection;
+import org.apache.kafka.common.message.OffsetForLeaderEpochResponseData.EpochEndOffset;
+import org.apache.kafka.common.message.OffsetForLeaderEpochResponseData.OffsetForLeaderTopicResult;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.record.RecordBatch;
+import org.apache.kafka.common.requests.AbstractRequest;
+import org.apache.kafka.common.requests.OffsetsForLeaderEpochRequest;
+import org.apache.kafka.common.requests.OffsetsForLeaderEpochResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Utility methods for preparing requests to the OffsetsForLeaderEpoch API and handling responses.
+ */
+public final class OffsetsForLeaderEpochUtils {
+
+    private static final Logger LOG = LoggerFactory.getLogger(OffsetsForLeaderEpochUtils.class);
+
+    private OffsetsForLeaderEpochUtils(){}
+
+    static AbstractRequest.Builder<OffsetsForLeaderEpochRequest> prepareRequest(
+            Map<TopicPartition, SubscriptionState.FetchPosition> requestData) {
+        OffsetForLeaderTopicCollection topics = new OffsetForLeaderTopicCollection(requestData.size());
+        requestData.forEach((topicPartition, fetchPosition) ->
+            fetchPosition.offsetEpoch.ifPresent(fetchEpoch -> {
+                OffsetForLeaderTopic topic = topics.find(topicPartition.topic());
+                if (topic == null) {
+                    topic = new OffsetForLeaderTopic().setTopic(topicPartition.topic());
+                    topics.add(topic);
+                }
+                topic.partitions().add(new OffsetForLeaderPartition()
+                    .setPartition(topicPartition.partition())
+                    .setLeaderEpoch(fetchEpoch)
+                    .setCurrentLeaderEpoch(fetchPosition.currentLeader.epoch
+                        .orElse(RecordBatch.NO_PARTITION_LEADER_EPOCH))
+                );
+            })
+        );
+        return OffsetsForLeaderEpochRequest.Builder.forConsumer(topics);
+    }
+
+    public static OffsetForEpochResult handleResponse(
+            Map<TopicPartition, SubscriptionState.FetchPosition> requestData,
+            OffsetsForLeaderEpochResponse response) {
+
+        Set<TopicPartition> partitionsToRetry = new HashSet<>(requestData.keySet());
+        Set<String> unauthorizedTopics = new HashSet<>();
+        Map<TopicPartition, EpochEndOffset> endOffsets = new HashMap<>();
+
+        for (OffsetForLeaderTopicResult topic : response.data().topics()) {
+            for (EpochEndOffset partition : topic.partitions()) {
+                TopicPartition topicPartition = new TopicPartition(topic.topic(), partition.partition());
+
+                if (!requestData.containsKey(topicPartition)) {
+                    LOG.warn("Received unrequested topic or partition {} from response, ignoring.", topicPartition);
+                    continue;
+                }
+
+                Errors error = Errors.forCode(partition.errorCode());
+                switch (error) {
+                    case NONE:
+                        LOG.debug("Handling OffsetsForLeaderEpoch response for {}. Got offset {} for epoch {}.",
+                            topicPartition, partition.endOffset(), partition.leaderEpoch());
+                        endOffsets.put(topicPartition, partition);
+                        partitionsToRetry.remove(topicPartition);
+                        break;
+                    case NOT_LEADER_OR_FOLLOWER:
+                    case REPLICA_NOT_AVAILABLE:
+                    case KAFKA_STORAGE_ERROR:
+                    case OFFSET_NOT_AVAILABLE:
+                    case LEADER_NOT_AVAILABLE:
+                    case FENCED_LEADER_EPOCH:
+                    case UNKNOWN_LEADER_EPOCH:
+                        LOG.debug("Attempt to fetch offsets for partition {} failed due to {}, retrying.",
+                            topicPartition, error);
+                        break;
+                    case UNKNOWN_TOPIC_OR_PARTITION:
+                        LOG.warn("Received unknown topic or partition error in OffsetsForLeaderEpoch request for partition {}.",
+                            topicPartition);
+                        break;
+                    case TOPIC_AUTHORIZATION_FAILED:
+                        unauthorizedTopics.add(topicPartition.topic());
+                        partitionsToRetry.remove(topicPartition);
+                        break;
+                    default:
+                        LOG.warn("Attempt to fetch offsets for partition {} failed due to: {}, retrying.",
+                            topicPartition, error.message());
+                }
+            }
+        }
+
+        if (!unauthorizedTopics.isEmpty())
+            throw new TopicAuthorizationException(unauthorizedTopics);
+        else
+            return new OffsetForEpochResult(endOffsets, partitionsToRetry);
+    }
+
+    static class OffsetForEpochResult {
+        private final Map<TopicPartition, EpochEndOffset> endOffsets;
+        private final Set<TopicPartition> partitionsToRetry;
+
+        OffsetForEpochResult(Map<TopicPartition, EpochEndOffset> endOffsets, Set<TopicPartition> partitionsNeedingRetry) {
+            this.endOffsets = endOffsets;
+            this.partitionsToRetry = partitionsNeedingRetry;
+        }
+
+        public Map<TopicPartition, EpochEndOffset> endOffsets() {
+            return endOffsets;
+        }
+
+        public Set<TopicPartition> partitionsToRetry() {
+            return partitionsToRetry;
+        }
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetsForLeaderEpochUtils.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetsForLeaderEpochUtils.java
@@ -118,8 +118,8 @@ public final class OffsetsForLeaderEpochUtils {
 
         if (!unauthorizedTopics.isEmpty())
             throw new TopicAuthorizationException(unauthorizedTopics);
-        else
-            return new OffsetForEpochResult(endOffsets, partitionsToRetry);
+
+        return new OffsetForEpochResult(endOffsets, partitionsToRetry);
     }
 
     static class OffsetForEpochResult {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetsRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetsRequestManager.java
@@ -18,6 +18,7 @@ package org.apache.kafka.clients.consumer.internals;
 
 import org.apache.kafka.clients.ApiVersions;
 import org.apache.kafka.clients.Metadata;
+import org.apache.kafka.clients.NodeApiVersions;
 import org.apache.kafka.clients.StaleMetadataException;
 import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
 import org.apache.kafka.clients.consumer.internals.OffsetFetcherUtils.ListOffsetData;
@@ -28,8 +29,11 @@ import org.apache.kafka.common.IsolationLevel;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.message.ListOffsetsRequestData;
+import org.apache.kafka.common.requests.AbstractRequest;
 import org.apache.kafka.common.requests.ListOffsetsRequest;
 import org.apache.kafka.common.requests.ListOffsetsResponse;
+import org.apache.kafka.common.requests.OffsetsForLeaderEpochRequest;
+import org.apache.kafka.common.requests.OffsetsForLeaderEpochResponse;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 import org.slf4j.Logger;
@@ -48,17 +52,22 @@ import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNull;
+import static org.apache.kafka.clients.consumer.internals.OffsetFetcherUtils.hasUsableOffsetForLeaderEpochVersion;
 
 /**
- * Manager responsible for building requests to retrieve partition offsets (see
- * {@link #fetchOffsets(Map, boolean)}). Requests are kept in-memory ready to be sent on the next
- * call to {@link #poll(long)}.
- * <p>
- * Partition leadership information required to build the requests is retrieved from the
+ * Manager responsible for building requests to retrieve partition offsets.
+ * <ul>
+ *      <li>ListOffset request</li>
+ *      <li>OffsetForLeaderEpoch request</li>
+ * </ul>
+ *
+ * Requests are kept in-memory ready to be sent on the next call to {@link #poll(long)}.
+ *
+ * Partition leadership information required to build ListOffset requests is retrieved from the
  * {@link ConsumerMetadata}, so this implements {@link ClusterResourceListener} to get notified
  * when the cluster metadata is updated.
  */
-public class ListOffsetsRequestManager implements RequestManager, ClusterResourceListener {
+public class OffsetsRequestManager implements RequestManager, ClusterResourceListener {
 
     private final ConsumerMetadata metadata;
     private final IsolationLevel isolationLevel;
@@ -70,15 +79,16 @@ public class ListOffsetsRequestManager implements RequestManager, ClusterResourc
     private final List<NetworkClientDelegate.UnsentRequest> requestsToSend;
     private final long requestTimeoutMs;
     private final Time time;
+    private final ApiVersions apiVersions;
 
-    public ListOffsetsRequestManager(final SubscriptionState subscriptionState,
-                                     final ConsumerMetadata metadata,
-                                     final IsolationLevel isolationLevel,
-                                     final Time time,
-                                     final long retryBackoffMs,
-                                     final long requestTimeoutMs,
-                                     final ApiVersions apiVersions,
-                                     final LogContext logContext) {
+    public OffsetsRequestManager(final SubscriptionState subscriptionState,
+                                 final ConsumerMetadata metadata,
+                                 final IsolationLevel isolationLevel,
+                                 final Time time,
+                                 final long retryBackoffMs,
+                                 final long requestTimeoutMs,
+                                 final ApiVersions apiVersions,
+                                 final LogContext logContext) {
         requireNonNull(subscriptionState);
         requireNonNull(metadata);
         requireNonNull(isolationLevel);
@@ -95,6 +105,7 @@ public class ListOffsetsRequestManager implements RequestManager, ClusterResourc
         this.subscriptionState = subscriptionState;
         this.time = time;
         this.requestTimeoutMs = requestTimeoutMs;
+        this.apiVersions = apiVersions;
         this.offsetFetcherUtils = new OffsetFetcherUtils(logContext, metadata, subscriptionState,
                 time, retryBackoffMs, apiVersions);
     }
@@ -159,8 +170,8 @@ public class ListOffsetsRequestManager implements RequestManager, ClusterResourc
     }
 
     /**
-     * Reset offsets for all assigned partitions that require it. Offsets will be reset
-     * with timestamps according to the reset strategy defined for each partition.
+     * Reset offsets for all assigned partitions that require it. Offsets will be reset with
+     * timestamps according to the reset strategy defined for each partition.
      * <p>
      * This may throw exception from previous offset fetch if there is one, ex.
      * TopicAuthorizationException
@@ -172,6 +183,14 @@ public class ListOffsetsRequestManager implements RequestManager, ClusterResourc
             return;
 
         List<NetworkClientDelegate.UnsentRequest> unsentRequests = sendListOffsetsRequestsAndResetPositions(offsetResetTimestamps);
+        requestsToSend.addAll(unsentRequests);
+    }
+
+    public void validatePositionsIfNeeded() {
+        Map<TopicPartition, SubscriptionState.FetchPosition> partitionsToValidate =
+                offsetFetcherUtils.getPartitionsToValidate();
+        List<NetworkClientDelegate.UnsentRequest> unsentRequests =
+                sendListOffsetsRequestsAndValidatePositions(partitionsToValidate);
         requestsToSend.addAll(unsentRequests);
     }
 
@@ -318,6 +337,46 @@ public class ListOffsetsRequestManager implements RequestManager, ClusterResourc
         return result;
     }
 
+    /**
+     * Build OffsetsForLeaderEpochRequest to send to a specific broker for the partitions and
+     * positions to fetch. This also adds the request to the list of unsentRequests.
+     **/
+    private CompletableFuture<OffsetsForLeaderEpochUtils.OffsetForEpochResult> sendOffsetsForLeaderEpochRequestToNode(
+            final Node node,
+            final Map<TopicPartition, SubscriptionState.FetchPosition> fetchPositions,
+            List<NetworkClientDelegate.UnsentRequest> unsentRequests) {
+        AbstractRequest.Builder<OffsetsForLeaderEpochRequest> builder =
+                OffsetsForLeaderEpochUtils.prepareRequest(fetchPositions);
+
+        log.debug("Creating OffsetsForLeaderEpochRequest request {} to broker {}", builder, node);
+
+        NetworkClientDelegate.UnsentRequest unsentRequest = new NetworkClientDelegate.UnsentRequest(
+                builder,
+                Optional.ofNullable(node));
+        unsentRequests.add(unsentRequest);
+        CompletableFuture<OffsetsForLeaderEpochUtils.OffsetForEpochResult> result = new CompletableFuture<>();
+        unsentRequest.future().whenComplete((response, error) -> {
+            if (error != null) {
+                log.error("Sending OffsetsForLeaderEpochRequest {} to broker {} failed",
+                        builder,
+                        node,
+                        error);
+                result.completeExceptionally(error);
+            } else {
+                OffsetsForLeaderEpochResponse lor = (OffsetsForLeaderEpochResponse) response.responseBody();
+                log.trace("Received OffsetsForLeaderEpochResponse {} from broker {}", lor, node);
+                try {
+                    OffsetsForLeaderEpochUtils.OffsetForEpochResult listOffsetResult =
+                            OffsetsForLeaderEpochUtils.handleResponse(fetchPositions, lor);
+                    result.complete(listOffsetResult);
+                } catch (RuntimeException e) {
+                    result.completeExceptionally(e);
+                }
+            }
+        });
+        return result;
+    }
+
     private List<NetworkClientDelegate.UnsentRequest> sendListOffsetsRequestsAndResetPositions(
             final Map<TopicPartition, Long> timestampsToSearch) {
         Map<Node, Map<TopicPartition, ListOffsetsRequestData.ListOffsetsPartition>> timestampsToSearchByNode =
@@ -325,15 +384,13 @@ public class ListOffsetsRequestManager implements RequestManager, ClusterResourc
 
         final List<NetworkClientDelegate.UnsentRequest> unsentRequests = new ArrayList<>();
 
-        for (Map.Entry<Node, Map<TopicPartition, ListOffsetsRequestData.ListOffsetsPartition>> entry : timestampsToSearchByNode.entrySet()) {
-            Node node = entry.getKey();
-            final Map<TopicPartition, ListOffsetsRequestData.ListOffsetsPartition> resetTimestamps = entry.getValue();
+        timestampsToSearchByNode.forEach((node, resetTimestamps) -> {
             subscriptionState.setNextAllowedRetry(resetTimestamps.keySet(),
                     time.milliseconds() + requestTimeoutMs);
 
             CompletableFuture<ListOffsetResult> partialResult = sendListOffsetRequestToNode(
                     node,
-                    entry.getValue(),
+                    resetTimestamps,
                     false,
                     unsentRequests);
 
@@ -351,7 +408,69 @@ public class ListOffsetsRequestManager implements RequestManager, ClusterResourc
                     }
                 }
             });
-        }
+        });
+        return unsentRequests;
+    }
+
+    /**
+     * For each partition which needs validation, make an asynchronous request to get the end-offsets for the partition
+     * with the epoch less than or equal to the epoch the partition last saw.
+     * <p/>
+     * Requests are grouped by Node for efficiency.
+     */
+    private List<NetworkClientDelegate.UnsentRequest> sendListOffsetsRequestsAndValidatePositions(
+            Map<TopicPartition, SubscriptionState.FetchPosition> partitionsToValidate) {
+
+        final Map<Node, Map<TopicPartition, SubscriptionState.FetchPosition>> regrouped =
+                offsetFetcherUtils.regroupFetchPositionsByLeader(partitionsToValidate);
+
+        long nextResetTimeMs = time.milliseconds() + requestTimeoutMs;
+        final List<NetworkClientDelegate.UnsentRequest> unsentRequests = new ArrayList<>();
+        regrouped.forEach((node, fetchPositions) -> {
+
+            if (node.isEmpty()) {
+                metadata.requestUpdate();
+                return;
+            }
+
+            NodeApiVersions nodeApiVersions = apiVersions.get(node.idString());
+            if (nodeApiVersions == null) {
+                // client.tryConnect(node);
+                return;
+            }
+
+            if (!hasUsableOffsetForLeaderEpochVersion(nodeApiVersions)) {
+                log.debug("Skipping validation of fetch offsets for partitions {} since the broker does not " +
+                                "support the required protocol version (introduced in Kafka 2.3)",
+                        fetchPositions.keySet());
+                for (TopicPartition partition : fetchPositions.keySet()) {
+                    subscriptionState.completeValidation(partition);
+                }
+                return;
+            }
+
+            subscriptionState.setNextAllowedRetry(fetchPositions.keySet(), nextResetTimeMs);
+
+            CompletableFuture<OffsetsForLeaderEpochUtils.OffsetForEpochResult> partialResult =
+                    sendOffsetsForLeaderEpochRequestToNode(node, fetchPositions, unsentRequests);
+
+            partialResult.whenComplete((offsetsResult, error) -> {
+                if (error == null) {
+                    offsetFetcherUtils.onSuccessfulRequestForValidatingPositions(fetchPositions,
+                            offsetsResult);
+                } else {
+                    if (error instanceof RuntimeException) {
+                        offsetFetcherUtils.onFailedRequestForValidatingPositions(fetchPositions,
+                                (RuntimeException) error);
+                    } else {
+                        log.error("Unexpected failure in OffsetsForLeaderEpochRequest for " +
+                                "validating positions", error);
+                    }
+                }
+            });
+
+        });
+
         return unsentRequests;
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetsRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetsRequestManager.java
@@ -435,7 +435,6 @@ public class OffsetsRequestManager implements RequestManager, ClusterResourceLis
 
             NodeApiVersions nodeApiVersions = apiVersions.get(node.idString());
             if (nodeApiVersions == null) {
-                // client.tryConnect(node);
                 return;
             }
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestManagers.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestManagers.java
@@ -47,7 +47,7 @@ public class RequestManagers<K, V> implements Closeable {
     private final Logger log;
     public final Optional<CoordinatorRequestManager> coordinatorRequestManager;
     public final Optional<CommitRequestManager> commitRequestManager;
-    public final ListOffsetsRequestManager listOffsetsRequestManager;
+    public final OffsetsRequestManager offsetsRequestManager;
     public final TopicMetadataRequestManager topicMetadataRequestManager;
     public final FetchRequestManager<K, V> fetchRequestManager;
 
@@ -55,13 +55,13 @@ public class RequestManagers<K, V> implements Closeable {
     private final IdempotentCloser closer = new IdempotentCloser();
 
     public RequestManagers(LogContext logContext,
-                           ListOffsetsRequestManager listOffsetsRequestManager,
+                           OffsetsRequestManager offsetsRequestManager,
                            TopicMetadataRequestManager topicMetadataRequestManager,
                            FetchRequestManager<K, V> fetchRequestManager,
                            Optional<CoordinatorRequestManager> coordinatorRequestManager,
                            Optional<CommitRequestManager> commitRequestManager) {
         this.log = logContext.logger(RequestManagers.class);
-        this.listOffsetsRequestManager = requireNonNull(listOffsetsRequestManager, "ListOffsetsRequestManager cannot be null");
+        this.offsetsRequestManager = requireNonNull(offsetsRequestManager, "OffsetsRequestManager cannot be null");
         this.coordinatorRequestManager = coordinatorRequestManager;
         this.commitRequestManager = commitRequestManager;
         this.topicMetadataRequestManager = topicMetadataRequestManager;
@@ -70,7 +70,7 @@ public class RequestManagers<K, V> implements Closeable {
         List<Optional<? extends RequestManager>> list = new ArrayList<>();
         list.add(coordinatorRequestManager);
         list.add(commitRequestManager);
-        list.add(Optional.of(listOffsetsRequestManager));
+        list.add(Optional.of(offsetsRequestManager));
         list.add(Optional.of(topicMetadataRequestManager));
         list.add(Optional.of(fetchRequestManager));
         entries = Collections.unmodifiableList(list);
@@ -124,7 +124,7 @@ public class RequestManagers<K, V> implements Closeable {
                 final FetchConfig<K, V> fetchConfig = createFetchConfig(config);
                 final long retryBackoffMs = config.getLong(ConsumerConfig.RETRY_BACKOFF_MS_CONFIG);
                 final long requestTimeoutMs = config.getLong(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG);
-                final ListOffsetsRequestManager listOffsets = new ListOffsetsRequestManager(subscriptions,
+                final OffsetsRequestManager listOffsets = new OffsetsRequestManager(subscriptions,
                         metadata,
                         isolationLevel,
                         time,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ResetPositionsApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ResetPositionsApplicationEvent.java
@@ -18,7 +18,10 @@
 package org.apache.kafka.clients.consumer.internals.events;
 
 /**
- * Event for resetting offsets for all assigned partitions that require it.
+ * Event for resetting offsets for all assigned partitions that require it. This is an
+ * asynchronous event that may complete right away if no partitions need reset, or may issue an
+ * asynchronous request to ListOffsets and then update positions in memory when a response is
+ * received.
  */
 public class ResetPositionsApplicationEvent extends CompletableApplicationEvent<Void> {
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ValidatePositionsApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ValidatePositionsApplicationEvent.java
@@ -14,27 +14,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.kafka.clients.consumer.internals.events;
 
-import java.util.Objects;
-
 /**
- * This is the abstract definition of the events created by the KafkaConsumer API
+ * Event for validating offsets for all assigned partitions for which a leader change has been
+ * detected. This is an asynchronous event that may complete right away if no partitions need
+ * validation, or may issue an asynchronous request to OffsetForLeaderEpoch and then update
+ * positions in memory when a response is received.
  */
-public abstract class ApplicationEvent {
+public class ValidatePositionsApplicationEvent extends CompletableApplicationEvent<Void> {
 
-    public enum Type {
-        NOOP, COMMIT, POLL, FETCH, FETCH_COMMITTED_OFFSET, METADATA_UPDATE, UNSUBSCRIBE,
-        LIST_OFFSETS, TOPIC_METADATA, RESET_POSITIONS, VALIDATE_POSITIONS
+    public ValidatePositionsApplicationEvent() {
+        super(Type.VALIDATE_POSITIONS);
     }
 
-    protected final Type type;
-
-    protected ApplicationEvent(Type type) {
-        this.type = Objects.requireNonNull(type);
-    }
-
-    public Type type() {
-        return type;
+    @Override
+    public String toString() {
+        return "ValidatePositions{" +
+                "future=" + future +
+                ", type=" + type +
+                '}';
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerTestBuilder.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerTestBuilder.java
@@ -66,7 +66,7 @@ public class ConsumerTestBuilder implements Closeable {
     final FetchConfig<String, String> fetchConfig;
     final FetchMetricsManager metricsManager;
     final NetworkClientDelegate networkClientDelegate;
-    final ListOffsetsRequestManager listOffsetsRequestManager;
+    final OffsetsRequestManager offsetsRequestManager;
     final TopicMetadataRequestManager topicMetadataRequestManager;
     final CoordinatorRequestManager coordinatorRequestManager;
     final CommitRequestManager commitRequestManager;
@@ -111,7 +111,7 @@ public class ConsumerTestBuilder implements Closeable {
                 config,
                 logContext,
                 client));
-        this.listOffsetsRequestManager = spy(new ListOffsetsRequestManager(subscriptions,
+        this.offsetsRequestManager = spy(new OffsetsRequestManager(subscriptions,
                 metadata,
                 isolationLevel,
                 time,
@@ -140,7 +140,7 @@ public class ConsumerTestBuilder implements Closeable {
                 metricsManager,
                 networkClientDelegate));
         this.requestManagers = new RequestManagers<>(logContext,
-                listOffsetsRequestManager,
+                offsetsRequestManager,
                 topicMetadataRequestManager,
                 fetchRequestManager,
                 Optional.of(coordinatorRequestManager),

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThreadTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThreadTest.java
@@ -66,7 +66,7 @@ public class DefaultBackgroundThreadTest {
     private CoordinatorRequestManager coordinatorManager;
     private CommitRequestManager commitManager;
     private TopicMetadataRequestManager topicMetadataRequestManager;
-    private ListOffsetsRequestManager listOffsetsRequestManager;
+    private OffsetsRequestManager offsetsRequestManager;
     private DefaultBackgroundThread<String, String> backgroundThread;
 
     @BeforeEach
@@ -80,7 +80,7 @@ public class DefaultBackgroundThreadTest {
         this.coordinatorManager = testBuilder.coordinatorRequestManager;
         this.commitManager = testBuilder.commitRequestManager;
         this.topicMetadataRequestManager = testBuilder.topicMetadataRequestManager;
-        this.listOffsetsRequestManager = testBuilder.listOffsetsRequestManager;
+        this.offsetsRequestManager = testBuilder.offsetsRequestManager;
         this.backgroundThread = testBuilder.backgroundThread;
         this.backgroundThread.initializeResources();
     }
@@ -165,7 +165,7 @@ public class DefaultBackgroundThreadTest {
     @Test
     public void testResetPositionsProcessFailureInterruptsBackgroundThread() {
         TopicAuthorizationException authException = new TopicAuthorizationException("Topic authorization failed");
-        doThrow(authException).when(listOffsetsRequestManager).resetPositionsIfNeeded();
+        doThrow(authException).when(offsetsRequestManager).resetPositionsIfNeeded();
 
         ResetPositionsApplicationEvent event = new ResetPositionsApplicationEvent();
         this.applicationEventsQueue.add(event);

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/OffsetForLeaderEpochClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/OffsetForLeaderEpochClientTest.java
@@ -55,7 +55,7 @@ public class OffsetForLeaderEpochClientTest {
     @Test
     public void testEmptyResponse() {
         OffsetsForLeaderEpochClient offsetClient = newOffsetClient();
-        RequestFuture<OffsetsForLeaderEpochClient.OffsetForEpochResult> future =
+        RequestFuture<OffsetsForLeaderEpochUtils.OffsetForEpochResult> future =
                 offsetClient.sendAsyncRequest(Node.noNode(), Collections.emptyMap());
 
         OffsetsForLeaderEpochResponse resp = new OffsetsForLeaderEpochResponse(
@@ -63,7 +63,7 @@ public class OffsetForLeaderEpochClientTest {
         client.prepareResponse(resp);
         consumerClient.pollNoWakeup();
 
-        OffsetsForLeaderEpochClient.OffsetForEpochResult result = future.value();
+        OffsetsForLeaderEpochUtils.OffsetForEpochResult result = future.value();
         assertTrue(result.partitionsToRetry().isEmpty());
         assertTrue(result.endOffsets().isEmpty());
     }
@@ -75,7 +75,7 @@ public class OffsetForLeaderEpochClientTest {
                 new Metadata.LeaderAndEpoch(Optional.empty(), Optional.of(1))));
 
         OffsetsForLeaderEpochClient offsetClient = newOffsetClient();
-        RequestFuture<OffsetsForLeaderEpochClient.OffsetForEpochResult> future =
+        RequestFuture<OffsetsForLeaderEpochUtils.OffsetForEpochResult> future =
                 offsetClient.sendAsyncRequest(Node.noNode(), positionMap);
 
         OffsetsForLeaderEpochResponse resp = new OffsetsForLeaderEpochResponse(
@@ -83,7 +83,7 @@ public class OffsetForLeaderEpochClientTest {
         client.prepareResponse(resp);
         consumerClient.pollNoWakeup();
 
-        OffsetsForLeaderEpochClient.OffsetForEpochResult result = future.value();
+        OffsetsForLeaderEpochUtils.OffsetForEpochResult result = future.value();
         assertFalse(result.partitionsToRetry().isEmpty());
         assertTrue(result.endOffsets().isEmpty());
     }
@@ -95,14 +95,14 @@ public class OffsetForLeaderEpochClientTest {
                 new Metadata.LeaderAndEpoch(Optional.empty(), Optional.of(1))));
 
         OffsetsForLeaderEpochClient offsetClient = newOffsetClient();
-        RequestFuture<OffsetsForLeaderEpochClient.OffsetForEpochResult> future =
+        RequestFuture<OffsetsForLeaderEpochUtils.OffsetForEpochResult> future =
                 offsetClient.sendAsyncRequest(Node.noNode(), positionMap);
 
         client.prepareResponse(prepareOffsetForLeaderEpochResponse(
             tp0, Errors.NONE, 1, 10L));
         consumerClient.pollNoWakeup();
 
-        OffsetsForLeaderEpochClient.OffsetForEpochResult result = future.value();
+        OffsetsForLeaderEpochUtils.OffsetForEpochResult result = future.value();
         assertTrue(result.partitionsToRetry().isEmpty());
         assertTrue(result.endOffsets().containsKey(tp0));
         assertEquals(result.endOffsets().get(tp0).errorCode(), Errors.NONE.code());
@@ -117,7 +117,7 @@ public class OffsetForLeaderEpochClientTest {
                 new Metadata.LeaderAndEpoch(Optional.empty(), Optional.of(1))));
 
         OffsetsForLeaderEpochClient offsetClient = newOffsetClient();
-        RequestFuture<OffsetsForLeaderEpochClient.OffsetForEpochResult> future =
+        RequestFuture<OffsetsForLeaderEpochUtils.OffsetForEpochResult> future =
                 offsetClient.sendAsyncRequest(Node.noNode(), positionMap);
 
         client.prepareResponse(prepareOffsetForLeaderEpochResponse(
@@ -136,7 +136,7 @@ public class OffsetForLeaderEpochClientTest {
                 new Metadata.LeaderAndEpoch(Optional.empty(), Optional.of(1))));
 
         OffsetsForLeaderEpochClient offsetClient = newOffsetClient();
-        RequestFuture<OffsetsForLeaderEpochClient.OffsetForEpochResult> future =
+        RequestFuture<OffsetsForLeaderEpochUtils.OffsetForEpochResult> future =
                 offsetClient.sendAsyncRequest(Node.noNode(), positionMap);
 
         client.prepareResponse(prepareOffsetForLeaderEpochResponse(
@@ -144,7 +144,7 @@ public class OffsetForLeaderEpochClientTest {
         consumerClient.pollNoWakeup();
 
         assertFalse(future.failed());
-        OffsetsForLeaderEpochClient.OffsetForEpochResult result = future.value();
+        OffsetsForLeaderEpochUtils.OffsetForEpochResult result = future.value();
         assertTrue(result.partitionsToRetry().contains(tp0));
         assertFalse(result.endOffsets().containsKey(tp0));
     }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/OffsetsRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/OffsetsRequestManagerTest.java
@@ -73,9 +73,9 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class ListOffsetsRequestManagerTest {
+public class OffsetsRequestManagerTest {
 
-    private ListOffsetsRequestManager requestManager;
+    private OffsetsRequestManager requestManager;
     private ConsumerMetadata metadata;
     private SubscriptionState subscriptionState;
     private MockTime time;
@@ -93,7 +93,7 @@ public class ListOffsetsRequestManagerTest {
         metadata = mock(ConsumerMetadata.class);
         subscriptionState = mock(SubscriptionState.class);
         this.time = new MockTime(0);
-        requestManager = new ListOffsetsRequestManager(subscriptionState, metadata,
+        requestManager = new OffsetsRequestManager(subscriptionState, metadata,
                 DEFAULT_ISOLATION_LEVEL, time, RETRY_BACKOFF_MS, REQUEST_TIMEOUT_MS,
                 mock(ApiVersions.class), new LogContext());
     }


### PR DESCRIPTION
Initial implementation for supporting validating positions & using it from the PrototypeConsumer by calling the updateFetchPositions. 

Regarding the ValidatePositions implementation:
- This introduces a new event type but reuses the same ListOffsetsRequestManager (renamed to OffsetsRequestManager). 
- The OffsetsRequestManager is responsible for offset-related requests (ListOffsets and OffsetForLeaderEpoch).
- The ValidatePositionsEvent is similar to the ResetPositionsEvent in the sense that it may perform a request when needed, processes the response async, and caches any exception that may happen. Cached exceptions are thrown in the next call to the validate/reset positions. 
