### PR TITLE
KAFKA-15188 - Minor PrototypeAsyncConsumer APIs fixes

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultEventHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultEventHandler.java
@@ -29,7 +29,6 @@ import org.slf4j.Logger;
 
 import java.time.Duration;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.concurrent.BlockingQueue;
 import java.util.function.Supplier;
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumer.java
@@ -975,7 +975,7 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
      * @throws org.apache.kafka.common.errors.AuthenticationException if authentication fails. See the exception for more details
      * @throws NoOffsetForPartitionException If no offset is stored for a given partition and no offset reset policy is
      *             defined
-     * @return true if the operation completed without timing out
+     * @return true iff the operation completed without timing out
      */
     private boolean updateFetchPositions() {
         // If any partitions have been truncated due to a leader change, we need to validate the offsets

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumer.java
@@ -985,6 +985,8 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
         cachedSubscriptionHasAllFetchPositions = subscriptions.hasAllFetchPositions();
         if (cachedSubscriptionHasAllFetchPositions) return true;
 
+        // TODO: integrate committed offsets related logic when supporting Kafka-based offsets management
+
         // If there are partitions still needing a position and a reset policy is defined,
         // request reset using the default policy. If no reset strategy is defined and there
         // are partitions with a missing position, then we will raise a NoOffsetForPartitionException exception.

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/CommitApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/CommitApplicationEvent.java
@@ -21,7 +21,6 @@ import org.apache.kafka.common.TopicPartition;
 
 import java.util.Collections;
 import java.util.Map;
-import java.util.Objects;
 
 public class CommitApplicationEvent extends CompletableApplicationEvent<Void> {
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ErrorEventHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ErrorEventHandlerTest.java
@@ -30,7 +30,6 @@ import java.util.concurrent.BlockingQueue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 


### PR DESCRIPTION
Follow-up on [PR#22](https://github.com/philipnee/kafka/pull/22)

Removes duplicated implementations, unused vars and fixes checkstyle errors. 