### PR TITLE
KAFKA-15270 - Simple Consume Integration tests

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
@@ -179,8 +179,10 @@ public class ApplicationEventProcessor<K, V> {
      */
     private boolean process(final ResetPositionsApplicationEvent event) {
         requestManagers.offsetsRequestManager.resetPositionsIfNeeded();
+        event.future().complete(null);
         // TODO: chain future to process failures at a higher level once the caching logic for
-        //  exceptions is reviewed/removed
+        //  exceptions is reviewed/removed. For now the event future indicates only that the
+        //  event has been processed.
         return true;
     }
 
@@ -193,8 +195,10 @@ public class ApplicationEventProcessor<K, V> {
      */
     private boolean process(final ValidatePositionsApplicationEvent event) {
         requestManagers.offsetsRequestManager.validatePositionsIfNeeded();
+        event.future().complete(null);
         // TODO: chain future to process failures at a higher level once the caching logic for
-        //  exceptions is reviewed/removed
+        //  exceptions is reviewed/removed. For now the event future indicates only that the
+        //  event has been processed.
         return true;
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumerTest.java
@@ -269,6 +269,12 @@ public class PrototypeAsyncConsumerTest {
                 ArgumentMatchers.isA(Timer.class));
     }
 
+    @Test
+    public void testPositionsOfUnassignedFails() {
+        TopicPartition tp = new TopicPartition("topic1", 0);
+        assertThrows(IllegalStateException.class, () -> consumer.position(tp));
+    }
+
     private HashMap<TopicPartition, OffsetAndMetadata> mockTopicPartitionOffset() {
         final TopicPartition t0 = new TopicPartition("t0", 2);
         final TopicPartition t1 = new TopicPartition("t0", 3);

--- a/core/src/test/scala/integration/kafka/api/BaseAsyncConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseAsyncConsumerTest.scala
@@ -17,11 +17,16 @@
 package kafka.api
 
 import kafka.utils.TestUtils.waitUntilTrue
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.common.PartitionInfo
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.{assertNotNull, assertNull, assertTrue}
 import org.junit.jupiter.api.Test
 
 import java.time.Duration
+import scala.collection.mutable
 import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.SeqHasAsJava
 
 
 class BaseAsyncConsumerTest extends AbstractConsumerTest {
@@ -61,5 +66,62 @@ class BaseAsyncConsumerTest extends AbstractConsumerTest {
     assertNotNull(committedOffset)
     assertNull(committedOffset.get(tp))
     assertTrue(consumer.assignment.contains(tp))
+  }
+
+  @Test
+  def testSimpleConsume(): Unit = {
+    val numRecords = 10
+
+    val producer = createProducer()
+    val startingTimestamp = System.currentTimeMillis()
+    sendRecords(producer, numRecords, tp, startingTimestamp = startingTimestamp)
+
+    val consumer = createConsumer(configsToRemove = List(ConsumerConfig.GROUP_ID_CONFIG))
+    consumer.assign(List(tp).asJava)
+    consumeAndVerifyRecords(consumer = consumer, numRecords, startingOffset = 0, startingTimestamp = startingTimestamp)
+
+    assertEquals(numRecords, consumer.position(tp))
+  }
+
+  @Test
+  def testSimpleConsumeSkippingPosition(): Unit = {
+    val numRecords = 10
+
+    val producer = createProducer()
+    val startingTimestamp = System.currentTimeMillis()
+    sendRecords(producer, numRecords, tp, startingTimestamp = startingTimestamp)
+
+    val consumer = createConsumer(configsToRemove = List(ConsumerConfig.GROUP_ID_CONFIG))
+    consumer.assign(List(tp).asJava)
+    val offset = 1
+    consumer.seek(tp, offset)
+    consumeAndVerifyRecords(consumer = consumer, numRecords - offset, startingOffset = offset,
+      startingKeyAndValueIndex = offset, startingTimestamp = startingTimestamp + offset)
+
+    assertEquals(numRecords, consumer.position(tp))
+  }
+
+  @Test
+  def testSimpleConsumeWithLeaderChangeValidatingPositions(): Unit = {
+    val numRecords = 10
+    val producer = createProducer()
+    val startingTimestamp = System.currentTimeMillis()
+    sendRecords(producer, numRecords, tp, startingTimestamp = startingTimestamp)
+    val consumer = createConsumer(configsToRemove = List(ConsumerConfig.GROUP_ID_CONFIG))
+    consumer.assign(List(tp).asJava)
+    consumeAndVerifyRecords(consumer = consumer, numRecords, startingOffset = 0, startingTimestamp = startingTimestamp)
+
+    // Force leader epoch change to trigger position validation
+    var parts: mutable.Buffer[PartitionInfo] = null
+    while (parts == null)
+      parts = consumer.partitionsFor(tp.topic()).asScala
+    val leader = parts.head.leader().id()
+    this.servers(leader).shutdown()
+    this.servers(leader).startup()
+
+    // Consume after leader change
+    sendRecords(producer, numRecords, tp, startingTimestamp = startingTimestamp)
+    consumeAndVerifyRecords(consumer = consumer, numRecords, startingOffset = 10,
+      startingTimestamp = startingTimestamp)
   }
 }


### PR DESCRIPTION
Initial integration tests for simple consume, including reset/validate positions functionality.

Includes also minor fixes & unit test
