### PR TITLE
KAFKA-15306 - Integrate refreshOffsets logic for fetching

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -16,9 +16,6 @@
  */
 package org.apache.kafka.clients.consumer.internals;
 
-import java.util.Arrays;
-import java.util.SortedSet;
-import java.util.TreeSet;
 import org.apache.kafka.clients.GroupRebalanceConfig;
 import org.apache.kafka.clients.consumer.CommitFailedException;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -41,11 +38,11 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.FencedInstanceIdException;
 import org.apache.kafka.common.errors.GroupAuthorizationException;
 import org.apache.kafka.common.errors.InterruptException;
-import org.apache.kafka.common.errors.UnstableOffsetCommitException;
 import org.apache.kafka.common.errors.RebalanceInProgressException;
 import org.apache.kafka.common.errors.RetriableException;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.errors.TopicAuthorizationException;
+import org.apache.kafka.common.errors.UnstableOffsetCommitException;
 import org.apache.kafka.common.errors.WakeupException;
 import org.apache.kafka.common.message.JoinGroupRequestData;
 import org.apache.kafka.common.message.JoinGroupResponseData;
@@ -72,6 +69,7 @@ import org.slf4j.Logger;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -80,6 +78,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -88,6 +88,7 @@ import java.util.stream.Collectors;
 
 import static org.apache.kafka.clients.consumer.ConsumerConfig.ASSIGN_FROM_SUBSCRIBED_ASSIGNORS;
 import static org.apache.kafka.clients.consumer.CooperativeStickyAssignor.COOPERATIVE_STICKY_ASSIGNOR_NAME;
+import static org.apache.kafka.clients.consumer.internals.Utils.refreshCommittedOffsets;
 
 /**
  * This class manages the coordination process with the consumer coordinator.
@@ -958,33 +959,8 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
         final Set<TopicPartition> initializingPartitions = subscriptions.initializingPartitions();
 
         final Map<TopicPartition, OffsetAndMetadata> offsets = fetchCommittedOffsets(initializingPartitions, timer);
-        if (offsets == null) return false;
 
-        for (final Map.Entry<TopicPartition, OffsetAndMetadata> entry : offsets.entrySet()) {
-            final TopicPartition tp = entry.getKey();
-            final OffsetAndMetadata offsetAndMetadata = entry.getValue();
-            if (offsetAndMetadata != null) {
-                // first update the epoch if necessary
-                entry.getValue().leaderEpoch().ifPresent(epoch -> this.metadata.updateLastSeenEpochIfNewer(entry.getKey(), epoch));
-
-                // it's possible that the partition is no longer assigned when the response is received,
-                // so we need to ignore seeking if that's the case
-                if (this.subscriptions.isAssigned(tp)) {
-                    final ConsumerMetadata.LeaderAndEpoch leaderAndEpoch = metadata.currentLeader(tp);
-                    final SubscriptionState.FetchPosition position = new SubscriptionState.FetchPosition(
-                            offsetAndMetadata.offset(), offsetAndMetadata.leaderEpoch(),
-                            leaderAndEpoch);
-
-                    this.subscriptions.seekUnvalidated(tp, position);
-
-                    log.info("Setting offset for partition {} to the committed offset {}", tp, position);
-                } else {
-                    log.info("Ignoring the returned {} since its partition {} is no longer assigned",
-                        offsetAndMetadata, tp);
-                }
-            }
-        }
-        return true;
+        return refreshCommittedOffsets(offsets, this.metadata, this.subscriptions);
     }
 
     /**


### PR DESCRIPTION
Logic for updating positions for fetching, using the committed offsets if available. 

This includes a refactoring of the ConsumerCoordinator to extract the reusable logic for `refreshCommittedOffsets` using the result of the OffsetFetch request. 