### PR TITLE
KAFKA-15316 - Invoking RequestState callbacks from CommitRequestManager

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
@@ -269,7 +269,7 @@ public class CommitRequestManager implements RequestManager {
         private void onFailure(final long currentTimeMs,
                                final Errors responseError) {
             log.debug("Offset fetch failed: {}", responseError.message());
-
+            requestState.onFailedAttempt(currentTimeMs);
             // TODO: should we retry on COORDINATOR_NOT_AVAILABLE as well ?
             if (responseError == Errors.COORDINATOR_LOAD_IN_PROGRESS) {
                 retry(currentTimeMs);
@@ -292,6 +292,7 @@ public class CommitRequestManager implements RequestManager {
 
         private void onSuccess(final long currentTimeMs,
                                final OffsetFetchResponse response) {
+            requestState.onSuccessfulAttempt(currentTimeMs);
             Set<String> unauthorizedTopics = null;
             Map<TopicPartition, OffsetFetchResponse.PartitionData> responseData =
                     response.partitionDataMap(groupState.groupId);


### PR DESCRIPTION
Adding missing call to the RequestState callbacks from CommitRequestManager. This ensures that the lastReceivedMs, backoff and attempts counters are properly updated when a response is received. 

This is the same that the CoordinatorRequestManager does when it receives a response to update the request state [see here](https://github.com/philipnee/kafka/blob/9c04a050a41184565c7a67c869f5b1168f2bd7b8/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CoordinatorRequestManager.java#L157)
