### PR TITLE
KAFKA-15270 - Integration test for shared committed offsets

### DIFF
--- a/core/src/test/scala/integration/kafka/api/BaseAsyncConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseAsyncConsumerTest.scala
@@ -104,11 +104,9 @@ class BaseAsyncConsumerTest extends AbstractConsumerTest {
       startingTimestamp = startingTimestamp)
     consumer.commitSync()
     assertEquals(numRecords, consumer.committed(Set(tp).asJava).get(tp).offset)
-    consumer.close()
 
     // We should see the committed offsets from another consumer
     val anotherConsumer = createConsumer()
-    anotherConsumer.assign(List(tp).asJava)
     assertEquals(numRecords, anotherConsumer.committed(Set(tp).asJava).get(tp).offset)
   }
 


### PR DESCRIPTION
Adding disabled test for collaboration, trying to sort out correct behaviour
Tests 2 consumers in group retrieving committed offsets