### PR TITLE
MINOR: CommitRequestManager may send commit before the coordinator node is discovered.

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
@@ -92,6 +92,10 @@ public class CommitRequestManager implements RequestManager {
      */
     @Override
     public NetworkClientDelegate.PollResult poll(final long currentTimeMs) {
+        if (!coordinatorRequestManager.coordinator().isPresent()) {
+            return new NetworkClientDelegate.PollResult(Long.MAX_VALUE, Collections.emptyList());
+        }
+        
         maybeAutoCommit(this.subscriptions.allConsumed());
         if (!pendingRequests.hasUnsentRequests()) {
             return new NetworkClientDelegate.PollResult(Long.MAX_VALUE, Collections.emptyList());

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
@@ -95,8 +95,9 @@ public class CommitRequestManager implements RequestManager {
         if (!coordinatorRequestManager.coordinator().isPresent()) {
             return new NetworkClientDelegate.PollResult(Long.MAX_VALUE, Collections.emptyList());
         }
-        
+
         maybeAutoCommit(this.subscriptions.allConsumed());
+
         if (!pendingRequests.hasUnsentRequests()) {
             return new NetworkClientDelegate.PollResult(Long.MAX_VALUE, Collections.emptyList());
         }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
@@ -97,7 +97,6 @@ public class CommitRequestManager implements RequestManager {
         }
 
         maybeAutoCommit(this.subscriptions.allConsumed());
-
         if (!pendingRequests.hasUnsentRequests()) {
             return new NetworkClientDelegate.PollResult(Long.MAX_VALUE, Collections.emptyList());
         }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CoordinatorRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CoordinatorRequestManager.java
@@ -127,7 +127,7 @@ public class CoordinatorRequestManager implements RequestManager {
      */
     public void markCoordinatorUnknown(final String cause, final long currentTimeMs) {
         if (this.coordinator != null) {
-            log.info("Group coordinator {} is unavailable or invalid due to cause: {}. "
+            log.info("Group coordinator {} is unavailable or invalid due to cause: {} "
                     + "Rediscovery will be attempted.", this.coordinator, cause);
             this.coordinator = null;
             timeMarkedUnknownMs = currentTimeMs;

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CommitRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CommitRequestManagerTest.java
@@ -20,6 +20,7 @@ import org.apache.kafka.clients.ClientResponse;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
@@ -67,6 +68,7 @@ public class CommitRequestManagerTest {
     private MockTime time;
     private CoordinatorRequestManager coordinatorRequestManager;
     private Properties props;
+    private Node mockedNode = new Node(1, "host1", 9092);
 
     @BeforeEach
     public void setup() {
@@ -80,6 +82,18 @@ public class CommitRequestManagerTest {
         this.props.put(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG, 100);
         this.props.put(KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         this.props.put(VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+    }
+
+    @Test
+    public void testPoll_SkipIfCoordinatorUnknown() {
+        CommitRequestManager commitRequestManger = create(false, 0);
+        when(coordinatorRequestManager.coordinator()).thenReturn(Optional.empty());
+        assertPoll(false, 0, commitRequestManger);
+
+        Map<TopicPartition, OffsetAndMetadata> offsets = new HashMap<>();
+        offsets.put(new TopicPartition("t1", 0), new OffsetAndMetadata(0));
+        commitRequestManger.addOffsetCommitRequest(offsets);
+        assertPoll(false, 0, commitRequestManger);
     }
 
     @Test
@@ -110,6 +124,7 @@ public class CommitRequestManagerTest {
     @Test
     public void testPoll_EnsureCorrectInflightRequestBufferSize() {
         CommitRequestManager commitManager = create(false, 100);
+        when(coordinatorRequestManager.coordinator()).thenReturn(Optional.of(mockedNode));
 
         // Create some offset commit requests
         Map<TopicPartition, OffsetAndMetadata> offsets1 = new HashMap<>();
@@ -146,6 +161,7 @@ public class CommitRequestManagerTest {
     @Test
     public void testPoll_EnsureEmptyPendingRequestAfterPoll() {
         CommitRequestManager commitRequestManger = create(true, 100);
+        when(coordinatorRequestManager.coordinator()).thenReturn(Optional.of(mockedNode));
         commitRequestManger.addOffsetCommitRequest(new HashMap<>());
         assertEquals(1, commitRequestManger.unsentOffsetCommitRequests().size());
         commitRequestManger.poll(time.milliseconds());
@@ -192,6 +208,7 @@ public class CommitRequestManagerTest {
     @Test
     public void testOffsetFetchRequest_EnsureDuplicatedRequestSucceed() {
         CommitRequestManager commitRequestManger = create(true, 100);
+        when(coordinatorRequestManager.coordinator()).thenReturn(Optional.of(mockedNode));
         Set<TopicPartition> partitions = new HashSet<>();
         partitions.add(new TopicPartition("t1", 0));
         List<CompletableFuture<Map<TopicPartition, OffsetAndMetadata>>> futures = sendAndVerifyDuplicatedRequests(
@@ -212,6 +229,8 @@ public class CommitRequestManagerTest {
     @MethodSource("exceptionSupplier")
     public void testOffsetFetchRequest_ErroredRequests(final Errors error, final boolean isRetriable) {
         CommitRequestManager commitRequestManger = create(true, 100);
+        when(coordinatorRequestManager.coordinator()).thenReturn(Optional.of(mockedNode));
+
         Set<TopicPartition> partitions = new HashSet<>();
         partitions.add(new TopicPartition("t1", 0));
         List<CompletableFuture<Map<TopicPartition, OffsetAndMetadata>>> futures = sendAndVerifyDuplicatedRequests(
@@ -255,6 +274,7 @@ public class CommitRequestManagerTest {
     @MethodSource("partitionDataErrorSupplier")
     public void testOffsetFetchRequest_PartitionDataError(final Errors error, final boolean isRetriable) {
         CommitRequestManager commitRequestManger = create(true, 100);
+        when(coordinatorRequestManager.coordinator()).thenReturn(Optional.of(mockedNode));
         Set<TopicPartition> partitions = new HashSet<>();
         TopicPartition tp1 = new TopicPartition("t1", 2);
         TopicPartition tp2 = new TopicPartition("t2", 3);
@@ -316,8 +336,20 @@ public class CommitRequestManagerTest {
     }
 
     private List<CompletableFuture<ClientResponse>> assertPoll(
-            final int numRes,
-            final CommitRequestManager manager) {
+        final int numRes,
+        final CommitRequestManager manager) {
+        return assertPoll(true, numRes, manager);
+    }
+
+    private List<CompletableFuture<ClientResponse>> assertPoll(
+        final boolean coordinatorDiscovered,
+        final int numRes,
+        final CommitRequestManager manager) {
+        if (coordinatorDiscovered) {
+            when(coordinatorRequestManager.coordinator()).thenReturn(Optional.of(mockedNode));
+        } else {
+            when(coordinatorRequestManager.coordinator()).thenReturn(Optional.empty());
+        }
         NetworkClientDelegate.PollResult res = manager.poll(time.milliseconds());
         assertEquals(numRes, res.unsentRequests.size());
 

--- a/core/src/test/scala/integration/kafka/api/BaseAsyncConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseAsyncConsumerTest.scala
@@ -146,7 +146,7 @@ class BaseAsyncConsumerTest extends AbstractConsumerTest {
   }
 
   @Test
-  def testConsumeFromCommittedOffsets(): Unit = {
+  def testFetchCommittedOffsets(): Unit = {
     val numRecords = 100
     val startingTimestamp = System.currentTimeMillis()
     val producer = createProducer()

--- a/core/src/test/scala/integration/kafka/api/BaseAsyncConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseAsyncConsumerTest.scala
@@ -144,4 +144,24 @@ class BaseAsyncConsumerTest extends AbstractConsumerTest {
     consumeAndVerifyRecords(consumer = consumer, numRecords, startingOffset = 10,
       startingTimestamp = startingTimestamp)
   }
+
+  @Test
+  def testConsumeFromCommittedOffsets(): Unit = {
+    val numRecords = 100
+    val startingTimestamp = System.currentTimeMillis()
+    val producer = createProducer()
+    sendRecords(producer, numRecords, tp, startingTimestamp = startingTimestamp)
+    val consumer = createAsyncConsumer()
+    consumer.assign(List(tp).asJava)
+    // First consumer consumes and commits offsets
+    consumer.seek(tp, 0)
+    consumeAndVerifyRecords(consumer = consumer, numRecords, startingOffset = 0,
+      startingTimestamp = startingTimestamp)
+    consumer.commitSync()
+    assertEquals(numRecords, consumer.committed(Set(tp).asJava).get(tp).offset)
+    // We should see the committed offsets from another consumer
+    val anotherConsumer = createAsyncConsumer()
+    anotherConsumer.assign(List(tp).asJava)
+    assertEquals(numRecords, anotherConsumer.committed(Set(tp).asJava).get(tp).offset)
+  }
 }


### PR DESCRIPTION
CommitRequestManager can send commit before the coordinator is discovered.  In this case, the request would get an empty Optional node, which implies the request can be route to any available node in the cluster.

To patch this, I amended a logic to only allow request manager poll when the coordinator node is available.