### PR TITLE
Fixes bugs causing tests in PlaintextAsyncConsumer to flake or fail

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClientUtils.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClientUtils.java
@@ -132,4 +132,12 @@ public final class NetworkClientUtils {
         if (exception != null)
             throw exception;
     }
+
+    /**
+     * Initiate a connection if currently possible. This is only really useful for resetting the
+     * failed status of a socket.
+     */
+    public static void tryConnect(KafkaClient client, Node node, Time time) {
+        client.ready(node, time.milliseconds());
+    }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractFetch.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractFetch.java
@@ -61,7 +61,7 @@ public abstract class AbstractFetch<K, V> implements Closeable {
     protected final FetchConfig<K, V> fetchConfig;
     protected final Time time;
     protected final FetchMetricsManager metricsManager;
-    protected final FetchBuffer<K, V> fetchBuffer;
+    protected final FetchBuffer fetchBuffer;
     protected final BufferSupplier decompressionBufferSupplier;
     protected final Set<Integer> nodesWithPendingFetchRequests;
     protected final IdempotentCloser idempotentCloser = new IdempotentCloser();
@@ -82,7 +82,7 @@ public abstract class AbstractFetch<K, V> implements Closeable {
         this.subscriptions = subscriptions;
         this.fetchConfig = fetchConfig;
         this.decompressionBufferSupplier = BufferSupplier.create();
-        this.fetchBuffer = new FetchBuffer<>(logContext);
+        this.fetchBuffer = new FetchBuffer(logContext);
         this.sessionHandlers = new HashMap<>();
         this.nodesWithPendingFetchRequests = new HashSet<>();
         this.metricsManager = metricsManager;
@@ -168,10 +168,9 @@ public abstract class AbstractFetch<K, V> implements Closeable {
                 log.debug("Fetch {} at offset {} for partition {} returned fetch data {}",
                         fetchConfig.isolationLevel, fetchOffset, partition, partitionData);
 
-                CompletedFetch<K, V> completedFetch = new CompletedFetch<>(
+                CompletedFetch completedFetch = new CompletedFetch(
                         logContext,
                         subscriptions,
-                        fetchConfig,
                         decompressionBufferSupplier,
                         partition,
                         partitionData,
@@ -276,7 +275,7 @@ public abstract class AbstractFetch<K, V> implements Closeable {
      * @param partition {@link TopicPartition} for which we want to fetch data
      * @param leaderReplica {@link Node} for the leader of the given partition
      * @param currentTimeMs Current time in milliseconds; used to determine if we're within the optional lease window
-     * @return Replic {@link Node node} from which to request the data
+     * @return Replica {@link Node node} from which to request the data
      * @see SubscriptionState#preferredReadReplica
      * @see SubscriptionState#updatePreferredReadReplica
      */
@@ -401,8 +400,8 @@ public abstract class AbstractFetch<K, V> implements Closeable {
     }
 
     /**
-     * This is guaranteed (by the {@link IdempotentCloser} to be executed only once the first time that
-     * any of the {@link #close()} methods are called.
+     * This is guaranteed (by the {@link IdempotentCloser}) to be executed only once the first
+     * time that any of the {@link #close()} methods are called.
      * @param timer Timer to enforce time limit
      */
     // Visible for testing

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CompletedFetch.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CompletedFetch.java
@@ -52,12 +52,10 @@ import java.util.Set;
 
 /**
  * {@link CompletedFetch} represents a {@link RecordBatch batch} of {@link Record records} that was returned from the
- * broker via a {@link FetchRequest}. It contains logic to maintain state between calls to {@link #fetchRecords(int)}.
- *
- * @param <K> Record key type
- * @param <V> Record value type
+ * broker via a {@link FetchRequest}. It contains logic to maintain state between calls to
+ * {@link #fetchRecords(FetchConfig, int)}.
  */
-public class CompletedFetch<K, V> {
+public class CompletedFetch {
 
     final TopicPartition partition;
     final FetchResponseData.PartitionData partitionData;
@@ -65,7 +63,6 @@ public class CompletedFetch<K, V> {
 
     private final Logger log;
     private final SubscriptionState subscriptions;
-    private final FetchConfig<K, V> fetchConfig;
     private final BufferSupplier decompressionBufferSupplier;
     private final Iterator<? extends RecordBatch> batches;
     private final Set<Long> abortedProducerIds;
@@ -86,7 +83,6 @@ public class CompletedFetch<K, V> {
 
     CompletedFetch(LogContext logContext,
                    SubscriptionState subscriptions,
-                   FetchConfig<K, V> fetchConfig,
                    BufferSupplier decompressionBufferSupplier,
                    TopicPartition partition,
                    FetchResponseData.PartitionData partitionData,
@@ -95,7 +91,6 @@ public class CompletedFetch<K, V> {
                    short requestVersion) {
         this.log = logContext.logger(CompletedFetch.class);
         this.subscriptions = subscriptions;
-        this.fetchConfig = fetchConfig;
         this.decompressionBufferSupplier = decompressionBufferSupplier;
         this.partition = partition;
         this.partitionData = partitionData;
@@ -140,7 +135,7 @@ public class CompletedFetch<K, V> {
     /**
      * Draining a {@link CompletedFetch} will signal that the data has been consumed and the underlying resources
      * are closed. This is somewhat analogous to {@link Closeable#close() closing}, though no error will result if a
-     * caller invokes {@link #fetchRecords(int)}; an empty {@link List list} will be returned instead.
+     * caller invokes {@link #fetchRecords(FetchConfig, int)}; an empty {@link List list} will be returned instead.
      */
     void drain() {
         if (!isConsumed) {
@@ -156,7 +151,7 @@ public class CompletedFetch<K, V> {
         }
     }
 
-    private void maybeEnsureValid(RecordBatch batch) {
+    private <K, V> void maybeEnsureValid(FetchConfig<K, V> fetchConfig, RecordBatch batch) {
         if (fetchConfig.checkCrcs && batch.magic() >= RecordBatch.MAGIC_VALUE_V2) {
             try {
                 batch.ensureValid();
@@ -167,7 +162,7 @@ public class CompletedFetch<K, V> {
         }
     }
 
-    private void maybeEnsureValid(Record record) {
+    private <K, V> void maybeEnsureValid(FetchConfig<K, V> fetchConfig, Record record) {
         if (fetchConfig.checkCrcs) {
             try {
                 record.ensureValid();
@@ -185,7 +180,7 @@ public class CompletedFetch<K, V> {
         }
     }
 
-    private Record nextFetchedRecord() {
+    private <K, V> Record nextFetchedRecord(FetchConfig<K, V> fetchConfig) {
         while (true) {
             if (records == null || !records.hasNext()) {
                 maybeCloseRecordStream();
@@ -204,7 +199,7 @@ public class CompletedFetch<K, V> {
 
                 currentBatch = batches.next();
                 lastEpoch = maybeLeaderEpoch(currentBatch.partitionLeaderEpoch());
-                maybeEnsureValid(currentBatch);
+                maybeEnsureValid(fetchConfig, currentBatch);
 
                 if (fetchConfig.isolationLevel == IsolationLevel.READ_COMMITTED && currentBatch.hasProducerId()) {
                     // remove from the aborted transaction queue all aborted transactions which have begun
@@ -230,7 +225,7 @@ public class CompletedFetch<K, V> {
                 // skip any records out of range
                 if (record.offset() >= nextFetchOffset) {
                     // we only do validation when the message should not be skipped.
-                    maybeEnsureValid(record);
+                    maybeEnsureValid(fetchConfig, record);
 
                     // control records are not returned to the user
                     if (!currentBatch.isControlBatch()) {
@@ -253,7 +248,7 @@ public class CompletedFetch<K, V> {
      * @param maxRecords The number of records to return; the number returned may be {@code 0 <= maxRecords}
      * @return {@link ConsumerRecord Consumer records}
      */
-    List<ConsumerRecord<K, V>> fetchRecords(int maxRecords) {
+    <K, V> List<ConsumerRecord<K, V>> fetchRecords(FetchConfig<K, V> fetchConfig, int maxRecords) {
         // Error when fetching the next record before deserialization.
         if (corruptLastRecord)
             throw new KafkaException("Received exception when fetching the next record from " + partition
@@ -271,7 +266,7 @@ public class CompletedFetch<K, V> {
                 // use the last record to do deserialization again.
                 if (cachedRecordException == null) {
                     corruptLastRecord = true;
-                    lastRecord = nextFetchedRecord();
+                    lastRecord = nextFetchedRecord(fetchConfig);
                     corruptLastRecord = false;
                 }
 
@@ -280,7 +275,7 @@ public class CompletedFetch<K, V> {
 
                 Optional<Integer> leaderEpoch = maybeLeaderEpoch(currentBatch.partitionLeaderEpoch());
                 TimestampType timestampType = currentBatch.timestampType();
-                ConsumerRecord<K, V> record = parseRecord(partition, leaderEpoch, timestampType, lastRecord);
+                ConsumerRecord<K, V> record = parseRecord(fetchConfig, partition, leaderEpoch, timestampType, lastRecord);
                 records.add(record);
                 recordsRead++;
                 bytesRead += lastRecord.sizeInBytes();
@@ -306,7 +301,8 @@ public class CompletedFetch<K, V> {
     /**
      * Parse the record entry, deserializing the key / value fields if necessary
      */
-    ConsumerRecord<K, V> parseRecord(TopicPartition partition,
+    <K, V> ConsumerRecord<K, V> parseRecord(FetchConfig<K, V> fetchConfig,
+                                     TopicPartition partition,
                                      Optional<Integer> leaderEpoch,
                                      TimestampType timestampType,
                                      Record record) {
@@ -324,6 +320,7 @@ public class CompletedFetch<K, V> {
                     valueBytes == null ? ConsumerRecord.NULL_SIZE : valueBytes.remaining(),
                     key, value, headers, leaderEpoch);
         } catch (RuntimeException e) {
+            log.error("Deserializers with error: {}", fetchConfig.deserializers);
             throw new RecordDeserializationException(partition, record.offset(),
                     "Error deserializing key/value for partition " + partition +
                             " at offset " + record.offset() + ". If needed, please seek past the record to continue consumption.", e);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerNetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerNetworkClient.java
@@ -585,10 +585,11 @@ public class ConsumerNetworkClient implements NodeStatusDetector, Closeable {
      * should be used.
      * @param node The node to connect to
      */
+    @Override
     public void tryConnect(Node node) {
         lock.lock();
         try {
-            client.ready(node, time.milliseconds());
+            NetworkClientUtils.tryConnect(client, node, time);
         } finally {
             lock.unlock();
         }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThread.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThread.java
@@ -121,7 +121,7 @@ public class DefaultBackgroundThread<K, V> extends KafkaThread implements Closea
         applicationEventQueue.drainTo(events);
 
         for (ApplicationEvent event : events) {
-            log.debug("Consuming application event: {}", event);
+            log.trace("Dequeued event: {}", event);
             Objects.requireNonNull(event);
             applicationEventProcessor.process(event);
         }
@@ -133,6 +133,7 @@ public class DefaultBackgroundThread<K, V> extends KafkaThread implements Closea
                 .filter(Objects::nonNull)
                 .map(this::handlePollResult)
                 .reduce(MAX_POLL_TIMEOUT_MS, Math::min);
+        networkClientDelegate.maybeTryConnect();
         networkClientDelegate.poll(pollWaitTimeMs, currentTimeMs);
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultEventHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultEventHandler.java
@@ -64,6 +64,7 @@ public class DefaultEventHandler<K, V> implements EventHandler {
     @Override
     public boolean add(final ApplicationEvent event) {
         Objects.requireNonNull(event, "ApplicationEvent provided to add must be non-null");
+        log.trace("Enqueued event: {}", event);
         backgroundThread.wakeup();
         return applicationEventQueue.add(event);
     }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Deserializers.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Deserializers.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.clients.consumer.internals;
 
+import java.util.StringJoiner;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.errors.InterruptException;
@@ -74,5 +75,13 @@ public class Deserializers<K, V> implements AutoCloseable {
             }
             throw new KafkaException("Failed to close deserializers", exception);
         }
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", Deserializers.class.getSimpleName() + "[", "]")
+            .add("keyDeserializer=" + keyDeserializer)
+            .add("valueDeserializer=" + valueDeserializer)
+            .toString();
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetchRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetchRequestManager.java
@@ -63,8 +63,6 @@ public class FetchRequestManager<K, V> extends AbstractFetch<K, V> implements Re
 
     @Override
     public PollResult poll(long currentTimeMs) {
-        log.debug("poll - currentTimeMs: {}", currentTimeMs);
-
         List<UnsentRequest> requests;
 
         if (!idempotentCloser.isClosed()) {
@@ -117,9 +115,9 @@ public class FetchRequestManager<K, V> extends AbstractFetch<K, V> implements Re
      *
      * @return {@link Queue} containing zero or more {@link CompletedFetch}
      */
-    public Queue<CompletedFetch<K, V>> drain() {
-        Queue<CompletedFetch<K, V>> q = new LinkedList<>();
-        CompletedFetch<K, V> completedFetch = fetchBuffer.poll();
+    public Queue<CompletedFetch> drain() {
+        Queue<CompletedFetch> q = new LinkedList<>();
+        CompletedFetch completedFetch = fetchBuffer.poll();
 
         while (completedFetch != null) {
             q.add(completedFetch);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/NodeStatusDetector.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/NodeStatusDetector.java
@@ -47,4 +47,12 @@ public interface NodeStatusDetector {
      * @see NetworkClientUtils#maybeThrowAuthFailure(KafkaClient, Node)
      */
     void maybeThrowAuthFailure(Node node);
+
+    /**
+     * Initiate a connection if currently possible. This is only really useful for resetting
+     * the failed status of a socket.
+     *
+     * @param node The node to connect to
+     */
+    void tryConnect(Node node);
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetsRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetsRequestManager.java
@@ -80,6 +80,7 @@ public class OffsetsRequestManager implements RequestManager, ClusterResourceLis
     private final long requestTimeoutMs;
     private final Time time;
     private final ApiVersions apiVersions;
+    private final NodeStatusDetector nodeStatusDetector;
 
     public OffsetsRequestManager(final SubscriptionState subscriptionState,
                                  final ConsumerMetadata metadata,
@@ -88,12 +89,14 @@ public class OffsetsRequestManager implements RequestManager, ClusterResourceLis
                                  final long retryBackoffMs,
                                  final long requestTimeoutMs,
                                  final ApiVersions apiVersions,
+                                 final NodeStatusDetector nodeStatusDetector,
                                  final LogContext logContext) {
         requireNonNull(subscriptionState);
         requireNonNull(metadata);
         requireNonNull(isolationLevel);
         requireNonNull(time);
         requireNonNull(apiVersions);
+        requireNonNull(nodeStatusDetector);
         requireNonNull(logContext);
 
         this.metadata = metadata;
@@ -106,6 +109,7 @@ public class OffsetsRequestManager implements RequestManager, ClusterResourceLis
         this.time = time;
         this.requestTimeoutMs = requestTimeoutMs;
         this.apiVersions = apiVersions;
+        this.nodeStatusDetector = nodeStatusDetector;
         this.offsetFetcherUtils = new OffsetFetcherUtils(logContext, metadata, subscriptionState,
                 time, retryBackoffMs, apiVersions);
     }
@@ -444,6 +448,7 @@ public class OffsetsRequestManager implements RequestManager, ClusterResourceLis
 
             NodeApiVersions nodeApiVersions = apiVersions.get(node.idString());
             if (nodeApiVersions == null) {
+                nodeStatusDetector.tryConnect(node);
                 return;
             }
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
@@ -56,12 +56,11 @@ public class ApplicationEventProcessor<K, V> {
         this.metadata = metadata;
     }
 
-    @SuppressWarnings("unchecked")
     public boolean process(final ApplicationEvent event) {
         Objects.requireNonNull(event, "Attempt to process null ApplicationEvent");
         Objects.requireNonNull(event.type(), "Attempt to process ApplicationEvent with null type: " + event);
 
-        log.debug("Processing event {}", event);
+        log.trace("Processing event: {}", event);
 
         // Make sure to use the event's type() method, not the type variable directly. This causes problems when
         // unit tests mock the EventType.
@@ -83,7 +82,7 @@ public class ApplicationEventProcessor<K, V> {
             case LIST_OFFSETS:
                 return process((ListOffsetsApplicationEvent) event);
             case FETCH:
-                return process((FetchEvent<K, V>) event);
+                return process((FetchEvent) event);
             case RESET_POSITIONS:
                 return process((ResetPositionsApplicationEvent) event);
             case VALIDATE_POSITIONS:
@@ -129,10 +128,10 @@ public class ApplicationEventProcessor<K, V> {
         return true;
     }
 
-    private boolean process(final FetchEvent<K, V> event) {
+    private boolean process(final FetchEvent event) {
         // The request manager keeps track of the completed fetches, so we pull any that are ready off, and return
         // them to the application.
-        Queue<CompletedFetch<K, V>> completedFetches = requestManagers.fetchRequestManager.drain();
+        Queue<CompletedFetch> completedFetches = requestManagers.fetchRequestManager.drain();
         event.future().complete(completedFetches);
         return true;
     }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/FetchEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/FetchEvent.java
@@ -23,7 +23,7 @@ import java.util.Queue;
 /**
  * This event signals the background thread to submit a fetch request.
  */
-public class FetchEvent<K, V> extends CompletableApplicationEvent<Queue<CompletedFetch<K, V>>> {
+public class FetchEvent extends CompletableApplicationEvent<Queue<CompletedFetch>> {
 
     public FetchEvent() {
         super(Type.FETCH);

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CompletedFetchTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CompletedFetchTest.java
@@ -67,19 +67,23 @@ public class CompletedFetchTest {
         FetchResponseData.PartitionData partitionData = new FetchResponseData.PartitionData()
                 .setRecords(newRecords(startingOffset, numRecords, fetchOffset));
 
-        CompletedFetch<String, String> completedFetch = newCompletedFetch(fetchOffset, partitionData);
+        FetchConfig<String, String> fetchConfig = newFetchConfig(new StringDeserializer(),
+            new StringDeserializer(),
+            IsolationLevel.READ_UNCOMMITTED,
+            true);
+        CompletedFetch completedFetch = newCompletedFetch(fetchOffset, partitionData);
 
-        List<ConsumerRecord<String, String>> records = completedFetch.fetchRecords(10);
+        List<ConsumerRecord<String, String>> records = completedFetch.fetchRecords(fetchConfig, 10);
         assertEquals(10, records.size());
         ConsumerRecord<String, String> record = records.get(0);
         assertEquals(10, record.offset());
 
-        records = completedFetch.fetchRecords(10);
+        records = completedFetch.fetchRecords(fetchConfig, 10);
         assertEquals(1, records.size());
         record = records.get(0);
         assertEquals(20, record.offset());
 
-        records = completedFetch.fetchRecords(10);
+        records = completedFetch.fetchRecords(fetchConfig, 10);
         assertEquals(0, records.size());
     }
 
@@ -92,21 +96,24 @@ public class CompletedFetchTest {
                 .setRecords(rawRecords)
                 .setAbortedTransactions(newAbortedTransactions());
 
-        CompletedFetch<String, String> completedFetch = newCompletedFetch(IsolationLevel.READ_COMMITTED,
-                OffsetResetStrategy.NONE,
-                true,
-                0,
-                partitionData);
-        List<ConsumerRecord<String, String>> records = completedFetch.fetchRecords(10);
-        assertEquals(0, records.size());
+        try (final StringDeserializer deserializer = new StringDeserializer()) {
+            FetchConfig<String, String> fetchConfig = newFetchConfig(deserializer,
+                deserializer,
+                IsolationLevel.READ_COMMITTED,
+                true);
+            CompletedFetch completedFetch = newCompletedFetch(0, partitionData);
+            List<ConsumerRecord<String, String>> records = completedFetch.fetchRecords(fetchConfig,
+                10);
+            assertEquals(0, records.size());
 
-        completedFetch = newCompletedFetch(IsolationLevel.READ_UNCOMMITTED,
-                OffsetResetStrategy.NONE,
-                true,
-                0,
-                partitionData);
-        records = completedFetch.fetchRecords(10);
-        assertEquals(numRecords, records.size());
+            fetchConfig = newFetchConfig(deserializer,
+                deserializer,
+                IsolationLevel.READ_UNCOMMITTED,
+                true);
+            completedFetch = newCompletedFetch(0, partitionData);
+            records = completedFetch.fetchRecords(fetchConfig, 10);
+            assertEquals(numRecords, records.size());
+        }
     }
 
     @Test
@@ -115,13 +122,17 @@ public class CompletedFetchTest {
         Records rawRecords = newTranscactionalRecords(ControlRecordType.COMMIT, numRecords);
         FetchResponseData.PartitionData partitionData = new FetchResponseData.PartitionData()
                 .setRecords(rawRecords);
-        CompletedFetch<String, String> completedFetch = newCompletedFetch(IsolationLevel.READ_COMMITTED,
-                OffsetResetStrategy.NONE,
-                true,
-                0,
+        CompletedFetch completedFetch = newCompletedFetch(0,
                 partitionData);
-        List<ConsumerRecord<String, String>> records = completedFetch.fetchRecords(10);
-        assertEquals(10, records.size());
+        try (final StringDeserializer deserializer = new StringDeserializer()) {
+            FetchConfig<String, String> fetchConfig = newFetchConfig(deserializer,
+                deserializer,
+                IsolationLevel.READ_COMMITTED,
+                true);
+            List<ConsumerRecord<String, String>> records = completedFetch.fetchRecords(fetchConfig,
+                10);
+            assertEquals(10, records.size());
+        }
     }
 
     @Test
@@ -132,9 +143,13 @@ public class CompletedFetchTest {
         FetchResponseData.PartitionData partitionData = new FetchResponseData.PartitionData()
                 .setRecords(newRecords(startingOffset, numRecords, fetchOffset));
 
-        CompletedFetch<String, String> completedFetch = newCompletedFetch(fetchOffset, partitionData);
+        CompletedFetch completedFetch = newCompletedFetch(fetchOffset, partitionData);
+        FetchConfig<String, String> fetchConfig = newFetchConfig(new StringDeserializer(),
+            new StringDeserializer(),
+            IsolationLevel.READ_UNCOMMITTED,
+            true);
 
-        List<ConsumerRecord<String, String>> records = completedFetch.fetchRecords(-10);
+        List<ConsumerRecord<String, String>> records = completedFetch.fetchRecords(fetchConfig, -10);
         assertEquals(0, records.size());
     }
 
@@ -146,96 +161,61 @@ public class CompletedFetchTest {
                 .setLastStableOffset(20)
                 .setLogStartOffset(0);
 
-        CompletedFetch<String, String> completedFetch = newCompletedFetch(IsolationLevel.READ_UNCOMMITTED,
-                OffsetResetStrategy.NONE,
-                false,
-                1,
+        CompletedFetch completedFetch = newCompletedFetch(1,
                 partitionData);
+        try (final StringDeserializer deserializer = new StringDeserializer()) {
+            FetchConfig<String, String> fetchConfig = newFetchConfig(deserializer,
+                deserializer,
+                IsolationLevel.READ_UNCOMMITTED,
+                true);
 
-        List<ConsumerRecord<String, String>> records = completedFetch.fetchRecords(10);
-        assertEquals(0, records.size());
+            List<ConsumerRecord<String, String>> records = completedFetch.fetchRecords(fetchConfig,
+                10);
+            assertEquals(0, records.size());
+        }
     }
 
     @Test
     public void testCorruptedMessage() {
         // Create one good record and then one "corrupted" record.
-        MemoryRecordsBuilder builder = MemoryRecords.builder(ByteBuffer.allocate(1024), CompressionType.NONE, TimestampType.CREATE_TIME, 0);
-        builder.append(new SimpleRecord(new UUIDSerializer().serialize(TOPIC_NAME, UUID.randomUUID())));
-        builder.append(0L, "key".getBytes(), "value".getBytes());
-        Records records = builder.build();
+        try (final MemoryRecordsBuilder builder = MemoryRecords.builder(ByteBuffer.allocate(1024), CompressionType.NONE, TimestampType.CREATE_TIME, 0);
+             final UUIDSerializer serializer = new UUIDSerializer();
+             final UUIDDeserializer deserializer = new UUIDDeserializer()) {
+            builder.append(new SimpleRecord(serializer.serialize(TOPIC_NAME, UUID.randomUUID())));
+            builder.append(0L, "key".getBytes(), "value".getBytes());
+            Records records = builder.build();
 
-        FetchResponseData.PartitionData partitionData = new FetchResponseData.PartitionData()
+            FetchResponseData.PartitionData partitionData = new FetchResponseData.PartitionData()
                 .setPartitionIndex(0)
                 .setHighWatermark(10)
                 .setLastStableOffset(20)
                 .setLogStartOffset(0)
                 .setRecords(records);
 
-        CompletedFetch<UUID, UUID> completedFetch = newCompletedFetch(new UUIDDeserializer(),
-                new UUIDDeserializer(),
+            FetchConfig<UUID, UUID> fetchConfig = newFetchConfig(deserializer,
+                deserializer,
                 IsolationLevel.READ_COMMITTED,
-                OffsetResetStrategy.NONE,
-                false,
-                0,
-                partitionData);
+                false);
+            CompletedFetch completedFetch = newCompletedFetch(0, partitionData);
 
-        completedFetch.fetchRecords(10);
+            completedFetch.fetchRecords(fetchConfig, 10);
 
-        assertThrows(RecordDeserializationException.class, () -> completedFetch.fetchRecords(10));
+            assertThrows(RecordDeserializationException.class,
+                () -> completedFetch.fetchRecords(fetchConfig, 10));
+        }
     }
 
-    private CompletedFetch<String, String> newCompletedFetch(long fetchOffset,
-                                                             FetchResponseData.PartitionData partitionData) {
-        return newCompletedFetch(
-                IsolationLevel.READ_UNCOMMITTED,
-                OffsetResetStrategy.NONE,
-                true,
-                fetchOffset,
-                partitionData);
-    }
-
-    private CompletedFetch<String, String> newCompletedFetch(IsolationLevel isolationLevel,
-                                                             OffsetResetStrategy offsetResetStrategy,
-                                                             boolean checkCrcs,
-                                                             long fetchOffset,
-                                                             FetchResponseData.PartitionData partitionData) {
-        return newCompletedFetch(new StringDeserializer(),
-                new StringDeserializer(),
-                isolationLevel,
-                offsetResetStrategy,
-                checkCrcs,
-                fetchOffset,
-                partitionData);
-    }
-
-    private <K, V> CompletedFetch<K, V> newCompletedFetch(Deserializer<K> keyDeserializer,
-                                                          Deserializer<V> valueDeserializer,
-                                                          IsolationLevel isolationLevel,
-                                                          OffsetResetStrategy offsetResetStrategy,
-                                                          boolean checkCrcs,
-                                                          long fetchOffset,
-                                                          FetchResponseData.PartitionData partitionData) {
+    private CompletedFetch newCompletedFetch(long fetchOffset,
+                                             FetchResponseData.PartitionData partitionData) {
         LogContext logContext = new LogContext();
-        SubscriptionState subscriptions = new SubscriptionState(logContext, offsetResetStrategy);
+        SubscriptionState subscriptions = new SubscriptionState(logContext, OffsetResetStrategy.NONE);
         FetchMetricsRegistry metricsRegistry = new FetchMetricsRegistry();
         FetchMetricsManager metrics = new FetchMetricsManager(new Metrics(), metricsRegistry);
         FetchMetricsAggregator metricAggregator = new FetchMetricsAggregator(metrics, Collections.singleton(TP));
 
-        FetchConfig<K, V> fetchConfig = new FetchConfig<>(
-                ConsumerConfig.DEFAULT_FETCH_MIN_BYTES,
-                ConsumerConfig.DEFAULT_FETCH_MAX_BYTES,
-                ConsumerConfig.DEFAULT_FETCH_MAX_WAIT_MS,
-                ConsumerConfig.DEFAULT_MAX_PARTITION_FETCH_BYTES,
-                ConsumerConfig.DEFAULT_MAX_POLL_RECORDS,
-                checkCrcs,
-                ConsumerConfig.DEFAULT_CLIENT_RACK,
-                new Deserializers<>(keyDeserializer, valueDeserializer),
-                isolationLevel
-        );
-        return new CompletedFetch<>(
+        return new CompletedFetch(
                 logContext,
                 subscriptions,
-                fetchConfig,
                 BufferSupplier.create(),
                 TP,
                 partitionData,
@@ -244,17 +224,36 @@ public class CompletedFetchTest {
                 ApiKeys.FETCH.latestVersion());
     }
 
+    private static <K, V> FetchConfig<K, V> newFetchConfig(Deserializer<K> keyDeserializer,
+                                                           Deserializer<V> valueDeserializer,
+                                                           IsolationLevel isolationLevel,
+                                                           boolean checkCrcs) {
+        return new FetchConfig<>(
+            ConsumerConfig.DEFAULT_FETCH_MIN_BYTES,
+            ConsumerConfig.DEFAULT_FETCH_MAX_BYTES,
+            ConsumerConfig.DEFAULT_FETCH_MAX_WAIT_MS,
+            ConsumerConfig.DEFAULT_MAX_PARTITION_FETCH_BYTES,
+            ConsumerConfig.DEFAULT_MAX_POLL_RECORDS,
+            checkCrcs,
+            ConsumerConfig.DEFAULT_CLIENT_RACK,
+            new Deserializers<>(keyDeserializer, valueDeserializer),
+            isolationLevel
+        );
+    }
+
     private Records newRecords(long baseOffset, int count, long firstMessageId) {
-        MemoryRecordsBuilder builder = MemoryRecords.builder(ByteBuffer.allocate(1024), CompressionType.NONE, TimestampType.CREATE_TIME, baseOffset);
-        for (int i = 0; i < count; i++)
-            builder.append(0L, "key".getBytes(), ("value-" + (firstMessageId + i)).getBytes());
-        return builder.build();
+        try (final MemoryRecordsBuilder builder = MemoryRecords.builder(ByteBuffer.allocate(1024), CompressionType.NONE, TimestampType.CREATE_TIME, baseOffset)) {
+            for (int i = 0; i < count; i++)
+                builder.append(0L, "key".getBytes(), ("value-" + (firstMessageId + i)).getBytes());
+            return builder.build();
+        }
     }
 
     private Records newTranscactionalRecords(ControlRecordType controlRecordType, int numRecords) {
         Time time = new MockTime();
         ByteBuffer buffer = ByteBuffer.allocate(1024);
-        MemoryRecordsBuilder builder = MemoryRecords.builder(buffer,
+
+        try (MemoryRecordsBuilder builder = MemoryRecords.builder(buffer,
                 RecordBatch.CURRENT_MAGIC_VALUE,
                 CompressionType.NONE,
                 TimestampType.CREATE_TIME,
@@ -264,12 +263,13 @@ public class CompletedFetchTest {
                 PRODUCER_EPOCH,
                 0,
                 true,
-                RecordBatch.NO_PARTITION_LEADER_EPOCH);
+                RecordBatch.NO_PARTITION_LEADER_EPOCH)) {
+            for (int i = 0; i < numRecords; i++)
+                builder.append(new SimpleRecord(time.milliseconds(), "key".getBytes(), "value".getBytes()));
 
-        for (int i = 0; i < numRecords; i++)
-            builder.append(new SimpleRecord(time.milliseconds(), "key".getBytes(), "value".getBytes()));
+            builder.build();
+        }
 
-        builder.build();
         writeTransactionMarker(buffer, controlRecordType, numRecords, time);
         buffer.flip();
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerTestBuilder.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerTestBuilder.java
@@ -121,7 +121,7 @@ public class ConsumerTestBuilder implements Closeable {
 
         this.subscriptions = createSubscriptionState(config, logContext);
         this.metadata = spy(new ConsumerMetadata(config, subscriptions, logContext, new ClusterResourceListeners()));
-        this.fetchConfig = createFetchConfig(config);
+        this.fetchConfig = createFetchConfig(config, new Deserializers<>(config));
         this.metricsManager = createFetchMetricsManager(metrics);
 
         this.client = new MockClient(time, metadata);
@@ -138,6 +138,7 @@ public class ConsumerTestBuilder implements Closeable {
                 retryBackoffMs,
                 requestTimeoutMs,
                 apiVersions,
+                networkClientDelegate,
                 logContext));
         this.topicMetadataRequestManager = spy(new TopicMetadataRequestManager(logContext, config));
         this.coordinatorRequestManager = spy(new CoordinatorRequestManager(time,
@@ -239,7 +240,7 @@ public class ConsumerTestBuilder implements Closeable {
                     logContext,
                     clientId,
                     new Deserializers<>(new StringDeserializer(), new StringDeserializer()),
-                    new FetchBuffer<>(logContext),
+                    new FetchBuffer(logContext),
                     fetchCollector,
                     new ConsumerInterceptors<>(Collections.emptyList()),
                     time,

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetchCollectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetchCollectorTest.java
@@ -82,7 +82,7 @@ public class FetchCollectorTest {
     private FetchConfig<String, String> fetchConfig;
     private FetchMetricsManager metricsManager;
     private ConsumerMetadata metadata;
-    private FetchBuffer<String, String> fetchBuffer;
+    private FetchBuffer fetchBuffer;
     private FetchCollector<String, String> fetchCollector;
     private CompletedFetchBuilder completedFetchBuilder;
 
@@ -92,7 +92,7 @@ public class FetchCollectorTest {
         buildDependencies();
         assignAndSeek(topicAPartition0);
 
-        CompletedFetch<String, String> completedFetch = completedFetchBuilder
+        CompletedFetch completedFetch = completedFetchBuilder
                 .recordCount(recordCount)
                 .build();
 
@@ -151,7 +151,7 @@ public class FetchCollectorTest {
         assertNotNull(subscriptions.preferredReadReplica(topicAPartition0, time.milliseconds()));
         assertEquals(Optional.of(preferredReadReplicaId), subscriptions.preferredReadReplica(topicAPartition0, time.milliseconds()));
 
-        CompletedFetch<String, String> completedFetch = completedFetchBuilder.build();
+        CompletedFetch completedFetch = completedFetchBuilder.build();
         fetchBuffer.add(completedFetch);
         Fetch<String, String> fetch = fetchCollector.collectFetch(fetchBuffer);
 
@@ -174,7 +174,7 @@ public class FetchCollectorTest {
         assertFalse(subscriptions.hasValidPosition(topicAPartition0));
 
         // Add some valid CompletedFetch records to the FetchBuffer queue and collect them into the Fetch.
-        CompletedFetch<String, String> completedFetch = completedFetchBuilder.build();
+        CompletedFetch completedFetch = completedFetchBuilder.build();
         fetchBuffer.add(completedFetch);
         Fetch<String, String> fetch = fetchCollector.collectFetch(fetchBuffer);
 
@@ -197,13 +197,13 @@ public class FetchCollectorTest {
                 time) {
 
             @Override
-            protected CompletedFetch<String, String> initialize(final CompletedFetch<String, String> completedFetch) {
+            protected CompletedFetch initialize(final CompletedFetch completedFetch) {
                 throw expectedException;
             }
         };
 
         // Add the CompletedFetch to the FetchBuffer queue
-        CompletedFetch<String, String> completedFetch = completedFetchBuilder
+        CompletedFetch completedFetch = completedFetchBuilder
                 .recordCount(recordCount)
                 .build();
         fetchBuffer.add(completedFetch);
@@ -230,7 +230,7 @@ public class FetchCollectorTest {
         subscriptions.pause(topicAPartition0);
         assertTrue(subscriptions.isPaused(topicAPartition0));
 
-        CompletedFetch<String, String> completedFetch = completedFetchBuilder.build();
+        CompletedFetch completedFetch = completedFetchBuilder.build();
 
         // Set the CompletedFetch to the next-in-line fetch, *not* the queue.
         fetchBuffer.setNextInLineFetch(completedFetch);
@@ -265,7 +265,7 @@ public class FetchCollectorTest {
         buildDependencies();
         assignAndSeek(topicAPartition0);
 
-        CompletedFetch<String, String> completedFetch = completedFetchBuilder
+        CompletedFetch completedFetch = completedFetchBuilder
                 .error(error)
                 .build();
         fetchBuffer.add(completedFetch);
@@ -288,7 +288,7 @@ public class FetchCollectorTest {
         buildDependencies();
         assignAndSeek(topicAPartition0);
 
-        CompletedFetch<String, String> completedFetch = completedFetchBuilder.build();
+        CompletedFetch completedFetch = completedFetchBuilder.build();
         fetchBuffer.add(completedFetch);
 
         // Fetch the data and validate that we get our first batch of records back.
@@ -327,7 +327,7 @@ public class FetchCollectorTest {
         assertNotNull(subscriptions.preferredReadReplica(topicAPartition0, time.milliseconds()));
         assertEquals(Optional.of(preferredReadReplicaId), subscriptions.preferredReadReplica(topicAPartition0, time.milliseconds()));
 
-        CompletedFetch<String, String> completedFetch = completedFetchBuilder
+        CompletedFetch completedFetch = completedFetchBuilder
                 .error(Errors.OFFSET_OUT_OF_RANGE)
                 .build();
         fetchBuffer.add(completedFetch);
@@ -344,7 +344,7 @@ public class FetchCollectorTest {
         assignAndSeek(topicAPartition0);
 
         // Try to data and validate that we get an empty Fetch back.
-        CompletedFetch<String, String> completedFetch = completedFetchBuilder
+        CompletedFetch completedFetch = completedFetchBuilder
                 .error(Errors.TOPIC_AUTHORIZATION_FAILED)
                 .build();
         fetchBuffer.add(completedFetch);
@@ -357,7 +357,7 @@ public class FetchCollectorTest {
         assignAndSeek(topicAPartition0);
 
         // Try to data and validate that we get an empty Fetch back.
-        CompletedFetch<String, String> completedFetch = completedFetchBuilder
+        CompletedFetch completedFetch = completedFetchBuilder
                 .error(Errors.UNKNOWN_LEADER_EPOCH)
                 .build();
         fetchBuffer.add(completedFetch);
@@ -371,7 +371,7 @@ public class FetchCollectorTest {
         assignAndSeek(topicAPartition0);
 
         // Try to data and validate that we get an empty Fetch back.
-        CompletedFetch<String, String> completedFetch = completedFetchBuilder
+        CompletedFetch completedFetch = completedFetchBuilder
                 .error(Errors.UNKNOWN_SERVER_ERROR)
                 .build();
         fetchBuffer.add(completedFetch);
@@ -385,7 +385,7 @@ public class FetchCollectorTest {
         assignAndSeek(topicAPartition0);
 
         // Try to data and validate that we get an empty Fetch back.
-        CompletedFetch<String, String> completedFetch = completedFetchBuilder
+        CompletedFetch completedFetch = completedFetchBuilder
                 .error(Errors.CORRUPT_MESSAGE)
                 .build();
         fetchBuffer.add(completedFetch);
@@ -398,7 +398,7 @@ public class FetchCollectorTest {
         buildDependencies();
         assignAndSeek(topicAPartition0);
 
-        CompletedFetch<String, String> completedFetch = completedFetchBuilder
+        CompletedFetch completedFetch = completedFetchBuilder
                 .error(error)
                 .build();
         fetchBuffer.add(completedFetch);
@@ -449,7 +449,7 @@ public class FetchCollectorTest {
                 fetchConfig,
                 metricsManager,
                 time);
-        fetchBuffer = new FetchBuffer<>(logContext);
+        fetchBuffer = new FetchBuffer(logContext);
         completedFetchBuilder = new CompletedFetchBuilder();
     }
 
@@ -541,7 +541,7 @@ public class FetchCollectorTest {
             return this;
         }
 
-        private CompletedFetch<String, String> build() {
+        private CompletedFetch build() {
             Records records;
             ByteBuffer allocate = ByteBuffer.allocate(1024);
 
@@ -564,10 +564,9 @@ public class FetchCollectorTest {
                 partitionData.setErrorCode(error.code());
 
             FetchMetricsAggregator metricsAggregator = new FetchMetricsAggregator(metricsManager, allPartitions);
-            return new CompletedFetch<>(
+            return new CompletedFetch(
                     logContext,
                     subscriptions,
-                    fetchConfig,
                     BufferSupplier.create(),
                     topicAPartition0,
                     partitionData,

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/OffsetsRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/OffsetsRequestManagerTest.java
@@ -103,7 +103,7 @@ public class OffsetsRequestManagerTest {
         this.apiVersions = mock(ApiVersions.class);
         requestManager = new OffsetsRequestManager(subscriptionState, metadata,
                 DEFAULT_ISOLATION_LEVEL, time, RETRY_BACKOFF_MS, REQUEST_TIMEOUT_MS,
-                apiVersions, new LogContext());
+                apiVersions, mock(NetworkClientDelegate.class), new LogContext());
     }
 
     @Test

--- a/core/src/test/scala/integration/kafka/api/PlaintextAsyncConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAsyncConsumerTest.scala
@@ -46,7 +46,6 @@ yet supported by the async consumer. Disabled tests will be enabled as the async
 evolves. The moment all tests are enabled this file will be deleted. */
 class PlaintextAsyncConsumer extends BaseConsumerTest {
 
-  @Disabled("Needs review for async consumer")
   @Test
   def testHeaders(): Unit = {
     val numRecords = 1
@@ -143,7 +142,6 @@ class PlaintextAsyncConsumer extends BaseConsumerTest {
     assertEquals(Set(tp, tp2), consumer.assignment().asScala)
   }
 
-  @Disabled("Needs review for async consumer")
   @Test
   def testHeadersSerializerDeserializer(): Unit = {
     val extendedSerializer = new Serializer[Array[Byte]] with SerializerImpl
@@ -632,7 +630,6 @@ class PlaintextAsyncConsumer extends BaseConsumerTest {
     producer.close()
   }
 
-  @Disabled("Needs review for async consumer - flaky")
   @Test
   def testPositionAndCommit(): Unit = {
     val producer = createProducer()
@@ -1327,7 +1324,6 @@ class PlaintextAsyncConsumer extends BaseConsumerTest {
     consumeAndVerifyRecords(consumer = consumer, numRecords = numRecords, tp = tp2, startingOffset = 0)
   }
 
-  @Disabled("Needs review for async consumer")
   @Test
   def testConsumeMessagesWithLogAppendTime(): Unit = {
     val topicName = "testConsumeMessagesWithLogAppendTime"
@@ -1646,7 +1642,6 @@ class PlaintextAsyncConsumer extends BaseConsumerTest {
     assertNotNull(fetchLag)
   }
 
-  @Disabled("Needs review for async consumer")
   @Test
   def testPerPartitionLeadWithMaxPollRecords(): Unit = {
     val numMessages = 1000
@@ -1692,7 +1687,6 @@ class PlaintextAsyncConsumer extends BaseConsumerTest {
     assertEquals(numMessages - records.count, lag.metricValue.asInstanceOf[Double], epsilon, s"The lag should be ${numMessages - records.count}")
   }
 
-  @Disabled("Needs review for async consumer")
   @Test
   def testQuotaMetricsNotCreatedIfNoQuotasConfigured(): Unit = {
     val numRecords = 1000
@@ -1841,7 +1835,6 @@ class PlaintextAsyncConsumer extends BaseConsumerTest {
         s"The current assignment is ${consumer.assignment()}")
   }
 
-  @Disabled("Needs review for async consumer - flaky")
   @Test
   def testConsumingWithNullGroupId(): Unit = {
     val topic = "test_topic"


### PR DESCRIPTION
This change fixes several tests in `PlaintextAsyncConsumer` that were flaky, allowing the `@Disabled` annotation to be removed for the following:

A lot of the changes in this commit are due to the `FetchConfig` and `FetchBuffer` no longer needing type parameterization. Thus all the type parameters in the users of either of these classes needed to be changed to omit them as well.

- `testHeaders`
- `testHeadersSerializerDeserializer`
- `testPositionAndCommit`
- `testConsumeMessagesWithLogAppendTime`
- `testPerPartitionLeadWithMaxPollRecords`
- `testQuotaMetricsNotCreatedIfNoQuotasConfigured`
- `testConsumingWithNullGroupId`

There were three causes for the flakiness:

# Use of the incorrect deserializer

Since the background thread doesn't perform deserialization, it doesn't need a `Deserializer`. So the background thread includes a "dummy" `Deserializer` in the `FetchConfig` that it creates. However, when the background thread created  `CompletedFetch` instances based on fetches, it stored a reference to the `FetchConfig` that includes the dummy `Deserializer` instance. When the `CompletedFetch` later converted its data into the `ConsumerRecord`, it attempted to use the dummy `Deserializer`, which threw errors.

The fix here is to remove the reference to the `FetchConfig` (which includes the `Deserializer`) and pass in the config at the point when we're creating the `ConsumerRecord` instances.

#  Node reconnection was not attempted for offsets

The `testPositionAndCommit` test had a timing issue where it would enter an infinite loop, unable to fetch any data. The reason for this boiled down to a difference between the offset management in `OffsetFetcher` and `OffsetsRequestManager`. When a given node did not have a `NodeApiVersions` object, the former class would attempt to connect to the node, whereas the latter did not. Without this node reconnection attempt, the `OffsetsRequestManager` forever considered the broker node down, never attempting to connect to it to handle the offset logic needed for fetch. Thus fetch would never be attempted for that node.

The fix was to reuse the node reconnection logic from `OffsetFetcher` in `OffsetsRequestManager`. One minor difference is that the latter doesn't _immediately_ attempt to reconnect; it notes the reconnect attempt and it is performed before the next call to `NetworkClient.poll()`.

This only affected the `testPositionAndCommit` test as it uses multiple `Consumer` instances and there was no previous network activity on the consumer to the node.

# Fetch timeout issues

At the end of `PrototypeAsyncConsumer.pollForFetches`, a blocking call for a `FetchEvent` is issued. This is an attempt to load any buffered fetch data that was previously retrieved for the `poll()` call. However, if no data is available within the timeout, another pass should be made to wait for the data. However, the error was that the timeout was not caught, causing the exception to propagate all the way up to the user.

The fix is to surround the `FetchEvent` call with a `try`/`catch` block that catches the timeout and lets processing continue. It's OK to catch the timeout as the calling method (`poll()`) checks that there is remaining time on the timer before looping again.